### PR TITLE
Replace multiplications, etc. with small matrices by explicit loops

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,114 +1,172 @@
-using BenchmarkTools, RData, MixedModels, StatsModels, Tables
+using BenchmarkTools, DataFrames, MixedModels, RData, StatsModels, Tables
 
 const SUITE = BenchmarkGroup()
 
-const dat = Dict(Symbol(k)=>columntable(v) for (k,v) in load(joinpath(dirname(pathof(MixedModels)), "..", "test", "dat.rda")));
+const dat = Dict(Symbol(k) => v for (k, v) in load(joinpath(
+    dirname(pathof(MixedModels)),
+    "..",
+    "test",
+    "dat.rda",
+)));
+
+categorical!(dat[:ml1m], [:G,:H])
 
 const mods = Dict{Symbol,Vector{Expr}}(
-    :Alfalfa => [:(1+A*B+(1|G)), :(1+A+B+(1|G))],
-    :Animal => [:(1+(1|G)+(1|H))],
-    :Arabidopsis => [],             # glmm and rename variables
+    :Alfalfa => [:(1 + A * B + (1 | G)), :(1 + A + B + (1 | G))],
+    :Animal => [:(1 + (1 | G) + (1 | H))],
+    :Arabidopsis => [],              # glmm and rename variables
     :Assay => [:(1+A+B*C+(1|G)+(1|H))],
-    :AvgDailyGain => [:(1+A*U+(1|G)), :(1+A+U+(1|G))],
-    :BIB => [:(1+A*U+(1|G)), :(1+A+U+(1|G))],
-    :Bond => [:(1+A+(1|G))],
-    :Chem97 => [:(1+(1|G)+(1|H)),:(1+U+(1|G)+(1|H))],
-    :Contraception => [],           # glmm and rename variables
-    :Cultivation => [:(1+A*B+(1|G)), :(1+A+B+(1|G)), :(1+A+(1|G))],
-    :Demand => [:(1+U+V+W+X+(1|G)+(1|H))],
-    :Dyestuff => [:(1+(1|G))],
-    :Dyestuff2 => [:(1+(1|G))],
-    :Early => [:(1+U+U&A+(1+U|G))],
-    :Exam => [:(1+A*U+B+(1|G)), :(1+A+B+U+(1|G))],
-    :Gasoline => [:(1+U+(1|G))],
-    :Gcsemv => [:(1+A+(1|G))],      # variables must be renamed
-    :Genetics => [:(1+A+(1|G)+(1|H))],
-    :HR => [:(1+A*U+V+(1+U|G))],
-    :Hsb82 => [:(1+A+B+C+U+(1|G))],
-    :IncBlk => [:(1+A+U+V+W+Z+(1|G))],
-    :InstEval => [:(1+A+(1|G)+(1|H)+(1|I)),:(1+A*I+(1|G)+(1|H))],
-    :KKL => [],                    # variables must be renamed
-    :KWDYZ => [],                  # variables must be renamed
-    :Mississippi => [:(1+A+(1|G))],
-    :Mmmec => [],                  # glmm (and offset) and variables renamed
-    :Multilocation => [:(1+A+(0+A|G)+(1|H))],
-    :Oxboys => [:(1+U+(1+U|G))],
-    :PBIB => [:(1+A+(1|G))],
-    :Pastes => [:(1+(1|G)+(1|H))],
-    :Penicillin => [:(1+(1|G)+(1|H))],
-    :Pixel => [:(1+U+V+(1+U|G)+(1|H))],  # variables must be renamed
-    :Poems => [:(1+U+V+W+(1|G)+(1|H)+(1|I))],
-    :Rail => [:(1+(1|G))],
-    :SIMS => [:(1+U+(1+U|G))],
-    :ScotsSec => [:(1+A+U+V+(1|G)+(1|H))],
-    :Semi2 => [:(1+A+(1|G)+(1|H))],
-    :Semiconductor => [:(1+A*B+(1|G))],
-    :Socatt => [],                 # variables must be renamed - binomial glmm?
-    :TeachingII => [:(1+A+T+U+V+W+X+Z+(1|G))],
-    :VerbAgg => [:(1+A+B+C+U+(1|G)+(1|H))], # Bernoulli glmm and rename variables
-    :Weights => [:(1+A*U+(1+U|G))],
-    :WWheat => [:(1+U+(1+U|G))],
-    :bdf => [],                   # rename variables and look up model
-    :bs10 => [:(1+U+V+W+((1+U+V+W)|G)+((1+U+V+W)|H))],
-    :cake => [:(1+A*B+(1|G))],
-    :cbpp => [:(1+A+(1|G))],      # Binomial glmm, create and rename variables
-    :d3 => [:(1+U+(1|G)+(1|H)+(1|I)), :(1+U+(1+U|G)+(1+U|H)+(1+U|I))],
-    :dialectNL => [:(1+A+T+U+V+W+X+(1|G)+(1|H)+(1|I))],
-    :egsingle => [:(1+A+U+V+(1|G)+(1|H))],
-    :epilepsy => [],              # unknown origin
-    :ergoStool => [:(1+A+(1|G))],
-    :gb12 => [:(1+S+T+U+V+W+X+Z+((1+S+U+W)|G)+((1+S+T+V)|H))],
-    :grouseticks => [],           # rename variables, glmm needs formula
-    :guImmun => [],               # rename variables, glmm needs formula
-    :guPrenat => [],              # rename variables, glmm needs formula
-    :kb07 => [:(1+S+T+U+V+W+X+Z+((1+S+T+U+V+W+X+Z)|G)+((1+S+T+U+V+W+X+Z)|H)),
-              :(1+S+T+U+V+W+X+Z+(1|G)+((0+S)|G)+((0+T)|G)+((0+U)|G)+((0+V)|G)+((0+W)|G)+
-              ((0+X)|G)+((0+Z)|G)+(1|H)+((0+S)|H)+((0+T)|H)+((0+U)|H)+((0+V)|H)+
-              ((0+W)|H)+((0+X)|H)+((0+Z)|H))],
-    :ml1m => [:(1+(1|G)+(1|H))],
-    :paulsim => [:(1+S+T+U+(1|H)+(1|G))],  # names of H and G should be reversed
-    :sleepstudy => [:(1+U+(1+U|G)), :(1+U+(1|G)+(0+U|G))],
-    :s3bbx => [],                 # probably drop this one
-    :star => []                   # not sure it is worthwhile working with these data
-    );
+    :AvgDailyGain => [:(1 + A * U + (1 | G)), :(1 + A + U + (1 | G))],
+    :BIB => [:(1 + A * U + (1 | G)), :(1 + A + U + (1 | G))],
+    :Bond => [:(1 + A + (1 | G))],
+    :Chem97 => [:(1 + (1 | G) + (1 | H)), :(1 + U + (1 | G) + (1 | H))],
+    :Contraception => [],            # glmm and rename variables
+    :Cultivation => [:(1 + A * B + (1 | G)), :(1 + A + B + (1 | G)), :(1 + A + (1 | G))],
+    :Demand => [:(1 + U + V + W + X + (1 | G) + (1 | H))],
+    :Dyestuff => [:(1 + (1 | G))],
+    :Dyestuff2 => [:(1 + (1 | G))],
+    :Early => [:(1 + U + U & A + (1 + U | G))],
+    :Exam => [:(1 + A * U + B + (1 | G)), :(1 + A + B + U + (1 | G))],
+    :Gasoline => [:(1 + U + (1 | G))],
+    :Gcsemv => [:(1 + A + (1 | G))], # variables must be renamed
+    :Genetics => [:(1 + A + (1 | G) + (1 | H))],
+    :HR => [:(1 + A * U + V + (1 + U | G))],
+    :Hsb82 => [:(1 + A + B + C + U + (1 | G))],
+    :IncBlk => [:(1 + A + U + V + W + Z + (1 | G))],
+    :InstEval => [:(1 + A + (1 | G) + (1 | H) + (1 | I)), :(1 + A * I + (1 | G) + (1 | H))],
+    :KKL => [],                      # variables must be renamed
+    :KWDYZ => [],                    # variables must be renamed
+    :Mississippi => [:(1 + A + (1 | G))],
+    :Mmmec => [],                    # glmm (and offset) and variables renamed
+    :Multilocation => [:(1 + A + (0 + A | G) + (1 | H))],
+    :Oxboys => [:(1 + U + (1 + U | G))],
+    :PBIB => [:(1 + A + (1 | G))],
+    :Pastes => [:(1 + (1 | G) + (1 | H))],
+    :Penicillin => [:(1 + (1 | G) + (1 | H))],
+    :Pixel => [:(1 + U + V + (1 + U | G) + (1 | H))],  # variables must be renamed
+    :Poems => [:(1 + U + V + W + (1 | G) + (1 | H) + (1 | I))],
+    :Rail => [:(1 + (1 | G))],
+    :SIMS => [:(1 + U + (1 + U | G))],
+    :ScotsSec => [:(1 + A + U + V + (1 | G) + (1 | H))],
+    :Semi2 => [:(1 + A + (1 | G) + (1 | H))],
+    :Semiconductor => [:(1 + A * B + (1 | G))],
+    :Socatt => [],                   # variables must be renamed - binomial glmm?
+    :TeachingII => [:(1 + A + T + U + V + W + X + Z + (1 | G))],
+    :VerbAgg => [:(1 + A + B + C + U + (1 | G) + (1 | H))], # Bernoulli glmm and rename variables
+    :Weights => [:(1 + A * U + (1 + U | G))],
+    :WWheat => [:(1 + U + (1 + U | G))],
+    :bdf => [],                      # rename variables and look up model
+    :bs10 => [:(1 + U + V + W + ((1 + U + V + W) | G) + ((1 + U + V + W) | H))],
+    :cake => [:(1 + A * B + (1 | G))],
+    :cbpp => [:(1 + A + (1 | G))],   # Binomial glmm, create and rename variables
+    :d3 => [
+        :(1 + U + (1 | G) + (1 | H) + (1 | I)),
+        :(1 + U + (1 + U | G) + (1 + U | H) + (1 + U | I)),
+    ],
+    :dialectNL => [:(1 + A + T + U + V + W + X + (1 | G) + (1 | H) + (1 | I))],
+    :egsingle => [:(1 + A + U + V + (1 | G) + (1 | H))],
+    :epilepsy => [],                 # unknown origin
+    :ergoStool => [:(1 + A + (1 | G))],
+    :gb12 => [:(1 + S + T + U + V + W + X + Z + ((1 + S + U + W) | G) +
+                ((1 + S + T + V) | H))],
+    :grouseticks => [],              # rename variables, glmm needs formula
+    :guImmun => [],                  # rename variables, glmm needs formula
+    :guPrenat => [],                 # rename variables, glmm needs formula
+    :kb07 => [
+        :(1 + S + T + U + V + W + X + Z + ((1 + S + T + U + V + W + X + Z) | G) +
+          ((1 + S + T + U + V + W + X + Z) | H)),
+        :(1 + S + T + U + V + W + X + Z + (1 | G) + ((0 + S) | G) + ((0 + T) | G) +
+          ((0 + U) | G) + ((0 + V) | G) + ((0 + W) | G) + ((0 + X) | G) + ((0 + Z) | G) +
+          (1 | H) + ((0 + S) | H) + ((0 + T) | H) + ((0 + U) | H) + ((0 + V) | H) +
+          ((0 + W) | H) + ((0 + X) | H) + ((0 + Z) | H)),
+    ],
+    :ml1m => [:(1 + (1 | G) + (1 | H))],
+    :paulsim => [:(1 + S + T + U + (1 | H) + (1 | G))],  # names of H and G should be reversed
+    :sleepstudy => [:(1 + U + (1 + U | G)), :(1 + U + (1 | G) + (0 + U | G))],
+    :s3bbx => [],                    # probably drop this one
+    :star => [],                     # not sure it is worthwhile working with these data
+);
 
-fitbobyqa(rhs::Expr, dsname::Symbol) = fit(LinearMixedModel, @eval(@formula(Y ~ $rhs)), dat[dsname])
-compactstr(ds,rhs) = replace(string(ds, ':', rhs), ' ' => "")
+fitbobyqa(rhs::Expr, dsname::Symbol) =
+    fit(MixedModel, @eval(@formula(Y ~ $rhs)), dat[dsname])
+compactstr(ds, rhs) = replace(string(ds, ':', rhs), ' ' => "")
 
 SUITE["simplescalar"] = BenchmarkGroup(["single", "simple", "scalar"])
-for ds in [:Alfalfa, :AvgDailyGain, :BIB, :Bond, :cake, :Cultivation, :Dyestuff,
-    :Dyestuff2, :ergoStool, :Exam, :Gasoline, :Hsb82, :IncBlk, :Mississippi,
-    :PBIB, :Rail, :Semiconductor, :TeachingII]
+for ds in [
+    :Alfalfa,
+    :AvgDailyGain,
+    :BIB,
+    :Bond,
+    :cake,
+    :Cultivation,
+    :Dyestuff,
+    :Dyestuff2,
+    :ergoStool,
+    :Exam,
+    :Gasoline,
+    :Hsb82,
+    :IncBlk,
+    :Mississippi,
+    :PBIB,
+    :Rail,
+    :Semiconductor,
+    :TeachingII,
+]
     for rhs in mods[ds]
-        SUITE["simplescalar"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        SUITE["simplescalar"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa(
+            $(QuoteNode(rhs)),
+            $(QuoteNode(ds)),
+        )
     end
 end
 
 SUITE["singlevector"] = BenchmarkGroup(["single", "vector"])
 for ds in [:Early, :HR, :Oxboys, :SIMS, :sleepstudy, :Weights, :WWheat]
     for rhs in mods[ds]
-        SUITE["singlevector"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        SUITE["singlevector"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa(
+            $(QuoteNode(rhs)),
+            $(QuoteNode(ds)),
+        )
     end
 end
 
 SUITE["nested"] = BenchmarkGroup(["multiple", "nested", "scalar"])
 for ds in [:Animal, :Chem97, :Genetics, :Pastes, :Semi2]
     for rhs in mods[ds]
-        SUITE["nested"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        SUITE["nested"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa(
+            $(QuoteNode(rhs)),
+            $(QuoteNode(ds)),
+        )
     end
 end
 
 SUITE["crossed"] = BenchmarkGroup(["multiple", "crossed", "scalar"])
-for ds in [:Assay, :Demand, :InstEval, :Penicillin, :ScotsSec,
-           :dialectNL, :egsingle, :ml1m, :paulsim]
+
+for ds in [
+    :Assay,
+    :Demand,
+    :InstEval,
+    :Penicillin,
+    :ScotsSec,
+    :dialectNL,
+    :egsingle,
+    :ml1m,
+    :paulsim,
+]
     for rhs in mods[ds]
-        SUITE["crossed"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        SUITE["crossed"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa(
+            $(QuoteNode(rhs)),
+            $(QuoteNode(ds)),
+        )
     end
 end
 
 SUITE["crossedvector"] = BenchmarkGroup(["multiple", "crossed", "vector"])
 for ds in [:bs10, :d3, :gb12, :kb07]
     for rhs in mods[ds]
-        SUITE["crossedvector"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa($(QuoteNode(rhs)), $(QuoteNode(ds)))
+        SUITE["crossedvector"][compactstr(ds, rhs)] = @benchmarkable fitbobyqa(
+            $(QuoteNode(rhs)),
+            $(QuoteNode(ds)),
+        )
     end
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,4 +1,4 @@
-using BenchmarkTools, DataFrames, MixedModels, RData, StatsModels, Tables
+using BenchmarkTools, DataFrames, MixedModels, RData, Tables
 
 const SUITE = BenchmarkGroup()
 
@@ -9,7 +9,7 @@ const dat = Dict(Symbol(k) => v for (k, v) in load(joinpath(
     "dat.rda",
 )));
 
-categorical!(dat[:ml1m], [:G,:H])
+categorical!(dat[:ml1m], [:G,:H]);  # forgot to convert these grouping factors
 
 const mods = Dict{Symbol,Vector{Expr}}(
     :Alfalfa => [:(1 + A * B + (1 | G)), :(1 + A + B + (1 | G))],

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -72,6 +72,24 @@ function LinearAlgebra.ldiv!(
     B
 end
 
+"""
+    _rdivlowertriblk!(A::AbstractMatrix, Bd::Array, b, S)
+
+Divide in-place a block of `S` columns of `A` starting at `(b-1)*s+1` on the right by the lower-triangular `b`th face of Bd.
+"""
+function _rdivlowertriblk!(A::AbstractMatrix, Bd::Array, b, S)
+    coloffset = (b - 1) * S
+    @inbounds @simd for i = 1:size(A, 1)
+        for j = 1:S
+            Aij = A[i, j + coloffset]
+            for k = 1:j-1
+                Aij -= A[i, k + coloffset] * Bd[j, k, b]'
+            end
+            A[i, j + coloffset] = Aij / Bd[j, j, b]'
+        end
+    end
+end
+
 function LinearAlgebra.rdiv!(
     A::Matrix{T},
     adjB::Adjoint{T,<:LowerTriangular{T,UniformBlockDiagonal{T}}},
@@ -80,17 +98,8 @@ function LinearAlgebra.rdiv!(
     Bd = adjB.parent.data
     r, s, blk = size(Bd.data)
     n == size(Bd, 1) && r == s || throw(DimensionMismatch())
-    @inbounds for b = 1:blk
-        coloffset = (b - 1) * s
-        for i = 1:m
-            for j = 1:s
-                Aij = A[i, j+coloffset]
-                for k = 1:j-1
-                    Aij -= A[i, k+coloffset] * Bd.data[j, k, b]'
-                end
-                A[i, j+coloffset] = Aij / Bd.data[j, j, b]'
-            end
-        end
+    for b = 1:blk
+        _rdivlowertriblk!(A, Bd.data, b, s)
     end
     A
 end

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -80,7 +80,7 @@ function LinearAlgebra.rdiv!(
     Bd = adjB.parent.data
     r, s, blk = size(Bd.data)
     n == size(Bd, 1) && r == s || throw(DimensionMismatch())
-    for b = 1:blk
+    @inbounds for b = 1:blk
         coloffset = (b - 1) * s
         for i = 1:m
             for j = 1:s
@@ -91,7 +91,6 @@ function LinearAlgebra.rdiv!(
                 A[i, j+coloffset] = Aij / Bd.data[j, j, b]'
             end
         end
-        A
     end
     A
 end

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -408,7 +408,7 @@ function rmulΛ!(A::M, B::ReMat{T,S}) where {M<:AbstractMatrix{T}} where {T,S}
     q, r = divrem(n, S)
     iszero(r) || throw(DimensionMismatch("size(A, 2) is not a multiple of block size"))
     Bd = B.λ.data
-    Threads.@threads for k = 1:q
+    for k = 1:q
         _rmullowertriblk!(A, Bd, (k - 1) * S, S)
     end
     A

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -391,7 +391,6 @@ function rmulΛ!(A::M, B::ReMat{T,S}) where {M<:AbstractMatrix{T}} where {T,S}
     q, r = divrem(n, S)
     iszero(r) || throw(DimensionMismatch("size(A, 2) is not a multiple of block size"))
     Bd = B.λ.data
-    m, n = size(A)
     @inbounds for k = 1:q
         coloffset = (k - 1) * S
         for i = 1:m

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -386,22 +386,30 @@ end
 
 rmulΛ!(A::M, B::ReMat{T,1}) where{M<:AbstractMatrix{T}} where{T} = rmul!(A, first(B.λ))
 
+"""
+    _rmullowertriblk!(A::AbstractMatrix{T}, Bd::Matrix, coloffset, S)
+
+Multiply in-place a block of `S` columns of `A` starting at `coloffset+1` on the right by the lower triangular `Bd`.
+"""
+function _rmullowertriblk!(A::AbstractMatrix, Bd::Matrix, coloffset, S)
+    @inbounds @simd for i = 1:size(A, 1)
+        for j = 1:S
+            Aij = A[i, j + coloffset] * Bd[j, j]
+            for k = j + 1:S
+                Aij += A[i, k + coloffset] * Bd[k, j]
+            end
+            A[i, j + coloffset] = Aij
+        end
+    end
+end
+
 function rmulΛ!(A::M, B::ReMat{T,S}) where {M<:AbstractMatrix{T}} where {T,S}
     m, n = size(A)
     q, r = divrem(n, S)
     iszero(r) || throw(DimensionMismatch("size(A, 2) is not a multiple of block size"))
     Bd = B.λ.data
-    @inbounds for k = 1:q
-        coloffset = (k - 1) * S
-        for i = 1:m
-            for j = 1:S
-                Aij = A[i, j + coloffset] * Bd[j, j]
-                for k = j + 1:S
-                    Aij += A[i, k + coloffset] * Bd[k, j]
-                end
-                A[i, j + coloffset] = Aij
-            end
-        end
+    Threads.@threads for k = 1:q
+        _rmullowertriblk!(A, Bd, (k - 1) * S, S)
     end
     A
 end
@@ -445,30 +453,40 @@ function scaleinflate!(Ljj::Matrix{T}, Λj::ReMat{T,1}) where {T}
     Ljj
 end
 
-function scaleinflate!(Ljj::UniformBlockDiagonal{T}, Λj::ReMat{T}) where {T}
+"""
+    _scaleinflateface!(A::Array, λ::Matrix, f, S)
+
+Replace the `f`'th `S×S` face of `A` by `λ'A[:,:,f]*λ + I` where `λ` is `S×S` lower triangular
+"""
+function _scaleinflateface!(A::Array, λ::Matrix, f, S)
+    @inbounds @simd for i = 1:S                   # rmul!(A[:,:,f], λ)
+        for j = 1:S
+            Aij = A[i, j, f] * λ[j, j]
+            for k = j + 1:S
+                Aij += A[i, k, f] * λ[k, j]
+            end
+            A[i, j, f] = Aij
+        end
+    end
+    for j = 1:S                  # lmul!(λ, A[:,:,f])
+        for i = 1:S
+            Aij = λ[i, i]'A[i, j, f]
+            for k = i + 1:S
+                Aij += λ[k, i]'A[k, j, f]
+            end
+            A[i, j, f] = Aij
+        end
+        A[j, j, f] += true      # inflate diagonal
+    end
+end
+
+function scaleinflate!(Ljj::UniformBlockDiagonal{T}, Λj::ReMat{T,S}) where {T,S}
     A = Ljj.data
     m, n, l = size(A)
+    m == n == S || throw(DimensionMismatch())
     λ = Λj.λ.data
-    @inbounds for f in 1:l
-        for i = 1:m                   # rmul!(A[:,:,f], λ)
-            for j = 1:n
-                Aij = A[i,j,f]*λ[j,j]
-                for k = j + 1:n
-                    Aij += A[i,k,f]*λ[k,j]
-                end
-                A[i,j,f] = Aij
-            end
-        end
-        for j = 1:n                  # lmul!(λ, A[:,:,f])
-            for i = 1:m
-                Aij = λ[i,i]'A[i,j,f]
-                for k = i + 1:m
-                    Aij += λ[k,i]'A[k,j,f]
-                end
-                A[i,j,f] = Aij
-            end
-            A[j,j,f] += one(T)      # inflate diagonal
-        end
+    for f in 1:l
+        _scaleinflateface!(A, λ, f, S)
     end
     Ljj
 end


### PR DESCRIPTION
Operations involving the potentially large matrix Λ involve stepping across blocks of columns (or rows) and applying a small triangular matrix,  λ.  By writing the inner operation as explicit loops instead of using views, a considerable amount of storage allocation can be avoided.