### PR TITLE
threaded parametric bootstrap

### DIFF
--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -92,4 +92,15 @@ end
 
 Return a vector of the values of `n` calls to `f()` - used in simulations where the value of `f` is stochastic.
 """
-replicate(f::Function, n) = [f() for _ in Base.OneTo(n)]
+# rng = MersenneTwister(42); replicate(10) do; [rand(rng,1),Threads.threadid()] ; end
+function replicate(f::Function, n)
+    # get the type
+    rr = f()
+    # pre-allocate
+    results = [rr for _ in Base.OneTo(n)]
+    Threads.@threads for idx = 2:n
+        results[idx] = f()
+    end
+
+    results
+end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -99,15 +99,19 @@ Note that if `f()` is not thread-safe or depends on a non thread-safe RNG,
 """
 function replicate(f::Function, n::Integer; use_threads=false)
     if use_threads
+        # no macro version yet: https://github.com/timholy/ProgressMeter.jl/issues/143
+        p = Progress(n)
         # get the type
         rr = f()
+        next!(p)
         # pre-allocate
         results = [rr for _ in Base.OneTo(n)]
         Threads.@threads for idx = 2:n
             results[idx] = f()
+            next!(p)
         end
     else
-        results = [f() for _ in Base.OneTo(n)]
+        results = @showprogress [f() for _ in Base.OneTo(n)]
     end
     results
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -88,14 +88,16 @@ function checkindprsk(k::Integer)
 end
 
 """
-    replicate(f::Function, n::Integer)
+    replicate(f::Function, n::Integer, use_threads=false)
 
 Return a vector of the values of `n` calls to `f()` - used in simulations where the value of `f` is stochastic.
 
-Note that if `f()` is not thread-safe or depends on a non thread-safe RNG, then you must set `use_threads=false`.
+Note that if `f()` is not thread-safe or depends on a non thread-safe RNG,
+    then you must set `use_threads=false`. Also note that ordering of replications
+    is not guaranteed when `use_threads=true`, although the replications are not
+    otherwise affected for thread-safe `f()`.
 """
-# rng = MersenneTwister(42); replicate(10) do; [rand(rng,1),Threads.threadid()] ; end
-function replicate(f::Function, n, use_threads=true)
+function replicate(f::Function, n::Integer; use_threads=false)
     if use_threads
         # get the type
         rr = f()

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -91,16 +91,21 @@ end
     replicate(f::Function, n::Integer)
 
 Return a vector of the values of `n` calls to `f()` - used in simulations where the value of `f` is stochastic.
+
+Note that if `f()` is not thread-safe or depends on a non thread-safe RNG, then you must set `use_threads=false`.
 """
 # rng = MersenneTwister(42); replicate(10) do; [rand(rng,1),Threads.threadid()] ; end
-function replicate(f::Function, n)
-    # get the type
-    rr = f()
-    # pre-allocate
-    results = [rr for _ in Base.OneTo(n)]
-    Threads.@threads for idx = 2:n
-        results[idx] = f()
+function replicate(f::Function, n, use_threads=true)
+    if use_threads
+        # get the type
+        rr = f()
+        # pre-allocate
+        results = [rr for _ in Base.OneTo(n)]
+        Threads.@threads for idx = 2:n
+            results[idx] = f()
+        end
+    else
+        results = [f() for _ in Base.OneTo(n)]
     end
-
     results
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -7,3 +7,17 @@ using LinearAlgebra, MixedModels, Random, SparseArrays, Test
 	@test MixedModels.densify(rsparsev) == Vector(rsparsev)
 	@test MixedModels.densify(Diagonal(rsparsev)) == Diagonal(Vector(rsparsev))
 end
+
+@testset "threaded_replicate" begin
+	rng = MersenneTwister(42);
+	single_thread = replicate(10,use_threads=false) do; randn(rng, 1)[1] ; end
+	rng = MersenneTwister(42);
+	multi_thread = replicate(10,use_threads=true) do
+		if Threads.threadid() % 2 == 0
+			sleep(0.001)
+		end
+		r = randn(rng, 1)[1];
+	end
+
+	@test all(sort!(single_thread) .== sort!(multi_thread))
+end


### PR DESCRIPTION
Introduce threading into `replicate`. 

Note that `replicate` now requires `f()` to be thread-safe. 

The naive version here seems to scale more or linearly with the number of threads up to the number of cores, but I'm still adding in locks to `simulate!` and `unscaledre!` to make them their RNG usage thread-safe. I've already added in thread-local storage so that they're not modifying the same model object.

