### PR TITLE
make zerocorr!(mod) mark the model as unfitted

### DIFF
--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -869,7 +869,7 @@ function zerocorr!(m::LinearMixedModel{T}, trmns) where {T}
     optsum.initial_step = T[]
 
     # the model is no longer fitted
-    optsum.feval == -1
+    optsum.feval = -1
 
     m
 end

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -550,10 +550,7 @@ vsize(A::ReMat{T,S}) where {T,S} = S
 function zerocorr!(A::ReMat{T}) where {T}
     λ = A.λ
     A.inds = intersect(A.inds, diagind(λ))
-    old_vals = [λ[i] for i in A.inds]
-    fill!(λ.data, 0)
-    for (old, idx) in enumerate(A.inds)
-        λ.data[idx] = old_vals[old]
-    end
+    # zero out all entries not on the diagonal
+    λ[setdiff(A.inds, diagind(λ))] .= 0
     A
 end

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -550,9 +550,10 @@ vsize(A::ReMat{T,S}) where {T,S} = S
 function zerocorr!(A::ReMat{T}) where {T}
     λ = A.λ
     A.inds = intersect(A.inds, diagind(λ))
+    old_vals = [λ[i] for i in A.inds]
     fill!(λ.data, 0)
-    for i in A.inds
-        λ.data[i] = 1
+    for (old, idx) in enumerate(A.inds)
+        λ.data[idx] = old_vals[old]
     end
     A
 end

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -220,7 +220,8 @@ end
 
     simulate!(fm)  # to test one of the unscaledre methods
 
-    fmnc = zerocorr!(LinearMixedModel(@formula(reaction ~ 1+days+ (1+days|subj)), slp))
+    fmnc = zerocorr!(deepcopy(fm))
+    @test fmnc.optsum.feval < 0
     @test size(fmnc) == (180,2,36,1)
     @test fmnc.θ == ones(2)
     @test lowerbd(fmnc) == zeros(2)

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -223,6 +223,11 @@ end
     fmnc = zerocorr!(deepcopy(fm))
     @test fmnc.optsum.feval < 0
     @test size(fmnc) == (180,2,36,1)
+    @test fmnc.θ == [fm.θ[1], fm.θ[3]]
+    @test lowerbd(fmnc) == zeros(2)
+
+    fmnc = zerocorr!(LMM(@formula(reaction ~ 1 + days + (1+days|subj)), slp));
+    @test size(fmnc) == (180,2,36,1)
     @test fmnc.θ == ones(2)
     @test lowerbd(fmnc) == zeros(2)
 


### PR DESCRIPTION
Fixes pretty obvious typo and sets up tests to actually catch this.

While looking at the `zerocorr!` code for this, it became clear that we don't re-use the relevant portions of the final theta vector as starting values when modifying and re-fitting an existing model. Is this a desideratum? 