### PR TITLE
fix up nesting (slash) syntax and add tests for fixefs too

### DIFF
--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -27,8 +27,14 @@ function StatsModels.apply_schema(
     if length(t.args_parsed) ≠ 2
         throw(ArgumentError("malformed nesting term: $t (Exactly two arguments required"))
     end
+
     first, second = apply_schema.(t.args_parsed, Ref(sch.schema), Mod)
-    return first + first & second
+
+    if !(typeof(first) <: CategoricalTerm)
+        throw(ArgumentError("nesting terms requires categorical grouping term, got $first.  Manually specify $first as `CategoricalTerm` in hints/contrasts"))
+    end
+
+    return first + fulldummy(first) & second
 end
 
 RandomEffectsTerm(lhs, rhs::NTuple{2,AbstractTerm}) =

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -28,8 +28,8 @@ function StatsModels.apply_schema(
         throw(ArgumentError("malformed nesting term: $t (Exactly two arguments required"))
     end
 
-    first, second = apply_schema.(t.args_parsed, Ref(sch.schema), Mod)
-
+    first, second = apply_schema.(t.args_parsed, Ref(sch), Mod)
+    
     if !(typeof(first) <: CategoricalTerm)
         throw(ArgumentError("nesting terms requires categorical grouping term, got $first.  Manually specify $first as `CategoricalTerm` in hints/contrasts"))
     end

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -175,5 +175,16 @@ end
 
         @test_broken fit(MixedModel, @formula(Y ~ 1 + (1|H/c)), dat[:Pastes])
 
+        # in fixed effects:
+        d2 = (a = rand(20), b = repeat([:X, :Y], outer=10))
+        f2 = apply_schema(@formula(0 ~ 1 + b/a), schema(d2), MixedModel)
+        @test modelcols(f2.rhs, d2) == [ones(20) d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
+        @test coefnames(f2.rhs) == ["(Intercept)", "b: Y", "b: X & a", "b: Y & a"]
+
+        f3 = apply_schema(@formula(0 ~ 0 + b/a), schema(d2), MixedModel)
+        @test modelcols(f3.rhs, d2) == [d2.b .== :X d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
+        @test coefnames(f3.rhs) == ["b: X", "b: Y", "b: X & a", "b: Y & a"]
+
+        
     end
 end

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -176,7 +176,7 @@ end
         @test_broken fit(MixedModel, @formula(Y ~ 1 + (1|H/c)), dat[:Pastes])
 
         # in fixed effects:
-        d2 = (a = rand(20), b = repeat([:X, :Y], outer=10))
+        d2 = (a = rand(20), b = repeat([:X, :Y], outer=10), c = repeat([:S,:T],outer=10))
         f2 = apply_schema(@formula(0 ~ 1 + b/a), schema(d2), MixedModel)
         @test modelcols(f2.rhs, d2) == [ones(20) d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
         @test coefnames(f2.rhs) == ["(Intercept)", "b: Y", "b: X & a", "b: Y & a"]
@@ -185,6 +185,10 @@ end
         @test modelcols(f3.rhs, d2) == [d2.b .== :X d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
         @test coefnames(f3.rhs) == ["b: X", "b: Y", "b: X & a", "b: Y & a"]
 
-        
+        # errors for continuous grouping
+        @test_throws ArgumentError apply_schema(@formula(0 ~ 1 + a/b), schema(d2), MixedModel)
+
+        # errors for too much nesting
+        @test_throws ArgumentError apply_schema(@formula(0 ~ 1 + b/c/a), schema(d2), MixedModel)
     end
 end


### PR DESCRIPTION
The existing implementation of `g/x` syntax (estimates effects of `x` for each
level of grouping factor `g`) almost works for fixed effects as well.

The syntax `g/x` is equivalent to `g + fulldummy(g) & x`.

This PR adds tests for fixed effects and fixes a few oversights that only apply
in the fixed effects setting (e.g., use the `FullRank` schema to make sure that
`g` is promoted to full rank if necessary; promote `g` to full rank dummy coding
for the nested component).

Ultimately this should be moved into a separate regression formulae package.
