### PR TITLE
convert incoming parameters in simulate! and parametric bootstrap

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -63,6 +63,9 @@ function parametricbootstrap(
     θ = morig.θ,
     use_threads = false,
 ) where {T}
+    β = convert(Vector{T},β)
+    σ = T(σ)
+    θ = convert(Vector{T},θ)
     βsc, θsc, p, k, m = similar(β), similar(θ), length(β), length(θ), deepcopy(morig)
     y₀ = copy(response(m))
     # we need to do for in-place operations to work across threads
@@ -151,6 +154,9 @@ function simulate!(
     σ = m.σ,
     θ = T[],
 ) where {T}
+    β = convert(Vector{T},β)
+    σ = T(σ)
+    θ = convert(Vector{T},θ)
     isempty(θ) || setθ!(m, θ)
 
     y = randn!(rng, response(m))      # initialize y to standard normal

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -304,6 +304,10 @@ end
 @testset "simulate!" begin
     ds = MixedModels.dataset(:dyestuff)
     fm = fit(MixedModel, @formula(yield ~ 1 + (1|batch)), ds)
+    resp₀ = copy(response(fm))
+    # type conversion of ints to floats
+    simulate!(Random.MersenneTwister(1234321), fm, β=[1], σ=1)
+    refit!(fm,resp₀)
     refit!(simulate!(Random.MersenneTwister(1234321), fm))
     @test deviance(fm) ≈ 339.0218639362958 atol=0.001
     refit!(fm, float(ds.yield))
@@ -313,6 +317,8 @@ end
     simulate!(fm, θ = fm.θ)
     @test_throws DimensionMismatch refit!(fm, zeros(29))
 
+    # type conversion of ints to floats
+    parametricbootstrap(Random.MersenneTwister(1234321), 1, fm, β=[1], σ=1)
     # this should give the same results as passing with
     # MersenneTwister(1234321)
     # by setting the seed first, we test the method for the default RNG


### PR DESCRIPTION
This has two benefits:

1. Careless passing of literal ints still works (common new user mistake)
2. We control when conversion occurs.
3. More meaningful feedback (point of error) for invalid conversions / fail earlier.