### PR TITLE
construct coeftable with hints for p-val and test-statistic cols

### DIFF
--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -176,7 +176,8 @@ function StatsBase.coeftable(m::MixedModel)
         hcat(co, se, z, pvalue),
         ["Estimate", "Std.Error", "z value", "P(>|z|)"],
         names,
-        4,
+        4, # pvalcol
+        3, # teststatcol
     )
 end
 

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -364,3 +364,10 @@ end
     @test coef(model2)[2] == -0.0
     @test last(fixef(model)) ≈ (last(fixef(model2)) * 1.5)
 end
+
+@testset "coeftable" begin
+    ds = MixedModels.dataset(:dyestuff);
+    fm = fit(MixedModel, @formula(yield ~ 1 + (1|batch)), ds);
+    ct = coeftable(fm);
+    @test [3,4] == [ct.teststatcol, ct.pvalcol]
+end


### PR DESCRIPTION
This makes it easier to manipulate the `coeftable` for the fixed effects.