### PR TITLE
update docs, fix copy-paste error for parametricbootstrap methods

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -53,6 +53,7 @@ The default random number generator is `Random.GLOBAL_RNG`.
 # Named Arguments
 
 `β`, `σ`, and `θ` are the values of `m`'s parameters for simulating the responses.
+`use_threads` determines whether or not to use thread-based parallelism. 
 """
 function parametricbootstrap(
     rng::AbstractRNG,
@@ -112,7 +113,7 @@ function parametricbootstrap(
 end
 
 function parametricbootstrap(nsamp::Integer, m::LinearMixedModel; β = m.β, σ = m.σ, θ = m.θ, use_threads = false)
-    parametricbootstrap(Random.GLOBAL_RNG, nsamp, m, β = β, σ = σ, θ = θ, use_threads = false)
+    parametricbootstrap(Random.GLOBAL_RNG, nsamp, m, β = β, σ = σ, θ = θ, use_threads = use_threads)
 end
 
 function Base.propertynames(bsamp::MixedModelBootstrap)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -42,9 +42,9 @@ issingular(bsamp::MixedModelBootstrap) = issingular.(Ref(bsamp.m), bsamp.θ)
 
 """
     parametricbootstrap(rng::AbstractRNG, nsamp::Integer, m::LinearMixedModel;
-        β = m.β, σ = m.σ, θ = m.θ)
+        β = coef(β), σ = m.σ, θ = m.θ, use_threads=false)
     parametricbootstrap(nsamp::Integer, m::LinearMixedModel;
-        β = m.β, σ = m.σ, θ = m.θ)
+        β = coef(β), σ = m.σ, θ = m.θ, use_threads=false)
 
 Perform `nsamp` parametric bootstrap replication fits of `m`, returning a `MixedModelBootstrap`.
 
@@ -53,7 +53,7 @@ The default random number generator is `Random.GLOBAL_RNG`.
 # Named Arguments
 
 `β`, `σ`, and `θ` are the values of `m`'s parameters for simulating the responses.
-`use_threads` determines whether or not to use thread-based parallelism. 
+`use_threads` determines whether or not to use thread-based parallelism.
 """
 function parametricbootstrap(
     rng::AbstractRNG,


### PR DESCRIPTION
Include `use_threads` in docstring and fix a copy-paste error for the implict RNG method.