### PR TITLE
use a named tuple with coefnames for β in simulate

### DIFF
--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -70,7 +70,7 @@ function parametricbootstrap(
     βsc_threads = [βsc]
     θsc_threads = [θsc]
 
-    β_names = (Symbol.(coefnames(morig))..., )
+    β_names = (Symbol.(fixefnames(morig))...)
     
     if use_threads
         Threads.resize_nthreads!(m_threads)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -70,7 +70,7 @@ function parametricbootstrap(
     βsc_threads = [βsc]
     θsc_threads = [θsc]
 
-    β_names = (Symbol.(fixefnames(morig))...)
+    β_names = (Symbol.(fixefnames(morig))..., )
     
     if use_threads
         Threads.resize_nthreads!(m_threads)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -70,6 +70,8 @@ function parametricbootstrap(
     βsc_threads = [βsc]
     θsc_threads = [θsc]
 
+    β_names = (Symbol.(coefnames(morig))..., )
+    
     if use_threads
         Threads.resize_nthreads!(m_threads)
         Threads.resize_nthreads!(βsc_threads)
@@ -90,7 +92,7 @@ function parametricbootstrap(
         (
          objective = mod.objective,
          σ = mod.σ,
-         β = SVector{p,T}(fixef!(βsc, mod)),
+         β = NamedTuple{β_names}(SVector{p,T}(fixef!(βsc, mod))),
          θ = SVector{k,T}(getθ!(θsc, mod)),
         )
     end


### PR DESCRIPTION
Self-explanatory.  Means that the vector of samples returned by
`getproperty(::MixedModelBootstrap, :β)` is a vector of named tuples, aka a row
table and can be converted into any other table (e.g. a `DataFrame`) easily.