### PR TITLE
new rePCA: now on correlations and with optional extra info

### DIFF
--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -373,7 +373,7 @@ function Base.getproperty(m::GeneralizedLinearMixedModel, s::Symbol)
         m.β
     elseif s ∈ (:σ, :sigma)
         sdest(m)
-    elseif s ∈ (:A, :L, :λ, :lowerbd, :optsum, :X, :reterms, :feterms, :formula, :σs, :σρs)
+    elseif s ∈ (:A, :L, :λ, :lowerbd, :PCA, :rePCA, :optsum, :X, :reterms, :feterms, :formula, :σs, :σρs)
         getproperty(m.LMM, s)
     elseif s == :y
         m.resp.y
@@ -566,6 +566,8 @@ for f in (
     :feL,
     :(LinearAlgebra.logdet),
     :lowerbd,
+    :PCA,
+    :rePCA,
     :(StatsModels.modelmatrix),
     :(StatsBase.vcov),
     :σs,

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -620,7 +620,7 @@ end
 LinearAlgebra.rank(m::LinearMixedModel) = first(m.feterms).rank
 
 """
-    rePCA(m::LinearMixedModel; loadings::Bool=false, corr::Bool=true)
+    rePCA(m::LinearMixedModel; corr::Bool=true)
 
 Return a named tuple of the normalized cumulative variance of a principal components
 analysis of the random effects covariance matrices or correlation
@@ -635,8 +635,15 @@ function rePCA(m::LinearMixedModel; corr::Bool=true)
     NamedTuple{fnames(m)}(getproperty.(pca,:cumvar))
 end
 
+"""
+    rePCA(m::LinearMixedModel; corr::Bool=true)
+
+Return a named tuple of the principal components analysis of the random effects
+covariance matrices or correlation matrices when `corr` is `true`.
+"""
+
 function PCA(m::LinearMixedModel; corr::Bool=true)
-    NamedTuple{fnames(m)}(PCA.(m.reterms))
+    NamedTuple{fnames(m)}(PCA.(m.reterms), corr=corr)
 end
 
 """

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -626,22 +626,17 @@ Return a named tuple of the normalized cumulative variance of a principal compon
 analysis of the random effects covariance matrices or correlation
 matrices when `corr` is `true`.
 
-If `loadings=true`, then a named tuple with two entries, one for the cumulative
-variances, and one for the loadings.
-
 The normalized cumulative variance is the proportion of the variance for the first
 principal component, the first two principal components, etc.  The last element is
 always 1.0 representing the complete proportion of the variance.
 """
-function rePCA(m::LinearMixedModel, corr::Bool=true; loadings::Bool=false)
-    pca = PCA.(m.reterms, corr)
-    if !loadings
-        NamedTuple{fnames(m)}(getproperty.(pca,:cumvar))
-    else
-        cumvar = NamedTuple{fnames(m)}(getproperty.(pca,:cumvar))
-        loadings = NamedTuple{fnames(m)}(getproperty.(pca,:loadings))
-        NamedTuple{(:cumvar,:loadings)}([cumvar,loadings])
-    end
+function rePCA(m::LinearMixedModel; corr::Bool=true)
+    pca = PCA.(m.reterms, corr=corr)
+    NamedTuple{fnames(m)}(getproperty.(pca,:cumvar))
+end
+
+function PCA(m::LinearMixedModel; corr::Bool=true)
+    NamedTuple{fnames(m)}(PCA.(m.reterms))
 end
 
 """

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -626,12 +626,22 @@ Return a named tuple of the normalized cumulative variance of a principal compon
 analysis of the random effects covariance matrices or correlation
 matrices when `corr` is `true`.
 
+If `loadings=true`, then a named tuple with two entries, one for the cumulative
+variances, and one for the loadings.
+
 The normalized cumulative variance is the proportion of the variance for the first
 principal component, the first two principal components, etc.  The last element is
 always 1.0 representing the complete proportion of the variance.
 """
-function rePCA(m::LinearMixedModel, corr::Bool=true, loadings::Bool=true)
-    NamedTuple{fnames(m)}(normalized_variance_cumsum.(m.reterms, loadings, corr))
+function rePCA(m::LinearMixedModel, corr::Bool=true; loadings::Bool=false)
+    pca = PCA.(m.reterms, corr)
+    if !loadings
+        NamedTuple{fnames(m)}(getproperty.(pca,:cumvar))
+    else
+        cumvar = NamedTuple{fnames(m)}(getproperty.(pca,:cumvar))
+        loadings = NamedTuple{fnames(m)}(getproperty.(pca,:loadings))
+        NamedTuple{(:cumvar,:loadings)}([cumvar,loadings])
+    end
 end
 
 """

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -636,7 +636,7 @@ function rePCA(m::LinearMixedModel; corr::Bool=true)
 end
 
 """
-    rePCA(m::LinearMixedModel; corr::Bool=true)
+    PCA(m::LinearMixedModel; corr::Bool=true)
 
 Return a named tuple of the principal components analysis of the random effects
 covariance matrices or correlation matrices when `corr` is `true`.

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -643,7 +643,7 @@ covariance matrices or correlation matrices when `corr` is `true`.
 """
 
 function PCA(m::LinearMixedModel; corr::Bool=true)
-    NamedTuple{fnames(m)}(PCA.(m.reterms), corr=corr)
+    NamedTuple{fnames(m)}(PCA.(m.reterms, corr=corr))
 end
 
 """

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -374,6 +374,11 @@ function *(adjA::Adjoint{T,<:ReMat{T,S}}, B::ReMat{T,P}) where {T,S,P}
     BlockedSparse{T,S,P}(cscmat, reshape(cscmat.nzval, S, :), cscmat.colptr[1:P:(cscmat.n + 1)])
 end
 
+PCA(A::ReMat{T,1}, corr::Bool=true) where {T} = 
+    PCA(corr ? abs.(vec(A.λ)) : ones(T,1), ones(T,1,1), corr)
+
+PCA(A::ReMat{T,S}, corr::Bool=true) where {T,S} = PCA(A.λ, corr)
+
 function reweight!(A::ReMat, sqrtwts::Vector)
     if length(sqrtwts) > 0
         if A.z === A.wtz

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -374,10 +374,10 @@ function *(adjA::Adjoint{T,<:ReMat{T,S}}, B::ReMat{T,P}) where {T,S,P}
     BlockedSparse{T,S,P}(cscmat, reshape(cscmat.nzval, S, :), cscmat.colptr[1:P:(cscmat.n + 1)])
 end
 
-PCA(A::ReMat{T,1}, corr::Bool=true) where {T} =
-    PCA(corr ? reshape(abs.(vec(A.λ)),1,1) : reshape(ones(T,1),1,1), corr)
+PCA(A::ReMat{T,1}; corr::Bool=true) where {T} =
+    PCA(corr ? reshape(abs.(vec(A.λ)),1,1) : reshape(ones(T,1),1,1), corr=corr)
 
-PCA(A::ReMat{T,S}, corr::Bool=true) where {T,S} = PCA(A.λ, corr)
+PCA(A::ReMat{T,S}; corr::Bool=true) where {T,S} = PCA(A.λ, corr=corr)
 
 function reweight!(A::ReMat, sqrtwts::Vector)
     if length(sqrtwts) > 0

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -374,8 +374,8 @@ function *(adjA::Adjoint{T,<:ReMat{T,S}}, B::ReMat{T,P}) where {T,S,P}
     BlockedSparse{T,S,P}(cscmat, reshape(cscmat.nzval, S, :), cscmat.colptr[1:P:(cscmat.n + 1)])
 end
 
-PCA(A::ReMat{T,1}, corr::Bool=true) where {T} = 
-    PCA(corr ? abs.(vec(A.λ)) : ones(T,1), ones(T,1,1), corr)
+PCA(A::ReMat{T,1}, corr::Bool=true) where {T} =
+    PCA(corr ? reshape(abs.(vec(A.λ)),1,1) : reshape(ones(T,1),1,1), corr)
 
 PCA(A::ReMat{T,S}, corr::Bool=true) where {T,S} = PCA(A.λ, corr)
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -79,6 +79,10 @@ function normalized_variance_cumsum(A::AbstractMatrix, corr::Bool=true)
     vars ./ last(vars)
 end
 
+normalized_variance_cumsum(A::ReMat, corr::Bool=true) =
+    normalized_variance_cumsum(A.λ, corr)
+
+
 """
     ltriindprs
 
@@ -165,26 +169,29 @@ function PCA(covfac::AbstractMatrix, corr::Bool=true)
     PCA(Symmetric(covf*covf', :L), svd(covf), corr)
 end
 
-function Base.show(io::IO, pca::PCA)
+PCA(re::ReMat, corr::Bool=true) = PCA(re.λ, corr)
+
+function Base.show(io::IO, pca::PCA, ndigitsmat=2, ndigitsvec=2, ndigitscum=4)
     println(io)
     println(io,
             "Principal components based on ",
             pca.corr ? "correlation" : "(relative) covariance",
             " matrix")
-    show(io, pca.covcor)
+    Base.print_matrix(io, round.(pca.covcor,digits=ndigitsmat))
     println(io)
     println(io, "Standard deviations:")
     sv = pca.sv
-    show(io, sv.S)
+    show(io, round.(sv.S,digits=ndigitsvec))
     println(io)
     println(io, "Variances:")
     vv = abs2.(sv.S)
-    show(io, vv)
+    show(io, round.(vv,digits=ndigitsvec))
     println(io)
     println(io, "Normalized cumulative variances:")
     cumvv = cumsum(vv)
-    show(io, cumvv ./ last(cumvv))
+    cumvv = cumvv ./ last(cumvv)
+    show(io, round.(cumvv,digits=ndigitscum))
     println(io)
     println(io, "Component loadings")
-    println(io, sv.U)
+    Base.print_matrix(io, round.(sv.U,digits=ndigitsmat))
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -62,21 +62,11 @@ end
 function rownormalize!(A::AbstractMatrix)
     for r in eachrow(A)
         # all zeros arise in zerocorr situations
-        if any(r .≉ 0)
+        if !iszero(r)
             normalize!(r)
         end
     end
     A
-end
-
-"""
-    normalized_variance_cumsum(A::AbstractMatrix, corr::Bool=true)
-
-Return the cumulative sum of the squared singular values of `A` normalized to sum to 1
-"""
-function normalized_variance_cumsum(A::AbstractMatrix, corr::Bool=true)
-    vars = cumsum(abs2.(svdvals(corr ? rownormalize!(copy(A)) : A)))
-    vars ./ last(vars)
 end
 
 """
@@ -169,8 +159,11 @@ end
 """
     PCA(::AbstractMatrix; corr::Bool=true)
     PCA(::ReMat; corr::Bool=true)
+    PCA(::LinearMixedModel; corr::Bool=true)
 
 Constructs a [`MixedModels.PCA`](@ref]) object from a covariance matrix.
+
+For `LinearMixedModel`, a named tuple of PCA on each of the random-effects terms is returned.
 
 If `corr=true`, then the covariance is first standardized to the correlation scale.
 """

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -61,7 +61,10 @@ end
 
 function rownormalize!(A::AbstractMatrix)
     for r in eachrow(A)
-        normalize!(r)
+        # all zeros arise in zerocorr situations
+        if any(r .≉ 0)
+            normalize!(r)
+        end
     end
     A
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -194,8 +194,8 @@ function Base.show(io::IO, pca::PCA;
                 "Principal components based on ",
                 pca.corr ? "correlation" : "(relative) covariance",
                 " matrix")
-        # TODO: find a print method that only displays the lower triangle
-        Base.print_matrix(io, round.(pca.covcor, digits=ndigitsmat))
+        # only display the lower triangle of symmetric matrix
+        Base.print_matrix(io, round.(LowerTriangular(pca.covcor), digits=ndigitsmat))
         println(io)
     end
     if stddevs

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -237,4 +237,6 @@ function Base.show(io::IO, pca::PCA;
         println(io, "Component loadings")
         Base.print_matrix(io, round.(pca.loadings, digits=ndigitsmat))
     end
+
+    nothing
 end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -193,6 +193,18 @@ Base.propertynames(pca::PCA, private = false) = (
 #    :rotation,
 )
 
+Base.show(pca::PCA;
+        ndigitsmat=2, ndigitsvec=2, ndigitscum=4,
+        covcor=true, loadings=true, variances=false, stddevs=false) =
+        Base.show(Base.stdout, pca,
+                    ndigitsmat=ndigitsmat,
+                    ndigitsvec=ndigitsvec,
+                    ndigitscum=ndigitscum,
+                    covcor=covcor,
+                    loadings=loadings,
+                    variances=variances,
+                    stddevs=stddevs)
+
 function Base.show(io::IO, pca::PCA;
         ndigitsmat=2, ndigitsvec=2, ndigitscum=4,
         covcor=true, loadings=true, variances=false, stddevs=false)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -153,12 +153,27 @@ datasets() = first.(Base.Filesystem.splitext.(filter(Base.Fix2(endswith, ".feath
     PCA{T<:AbstractFloat}
 
 Principal Components Analysis
+
+## Fields
+
+* `covcorr` covariance or correlation matrix
+* `sv` singular value decomposition
+* `corr` is this a correlation matrix
 """
 struct PCA{T<:AbstractFloat}
     covcor::Symmetric{T,Matrix{T}}
     sv::SVD{T,T,Matrix{T}}
     corr::Bool
 end
+
+"""
+    PCA(::AbstractMatrix; corr::Bool=true)
+    PCA(::ReMat; corr::Bool=true)
+
+Constructs a [`MixedModels.PCA`](@ref]) object from a covariance matrix.
+
+If `corr=true`, then the covariance is first standardized to the correlation scale.
+"""
 
 function PCA(covfac::AbstractMatrix; corr::Bool=true)
     covf = corr ? rownormalize!(copy(covfac)) : copy(covfac)

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -79,10 +79,6 @@ function normalized_variance_cumsum(A::AbstractMatrix, corr::Bool=true)
     vars ./ last(vars)
 end
 
-normalized_variance_cumsum(A::ReMat, corr::Bool=true) =
-    normalized_variance_cumsum(A.λ, corr)
-
-
 """
     ltriindprs
 
@@ -169,8 +165,6 @@ function PCA(covfac::AbstractMatrix, corr::Bool=true)
     PCA(Symmetric(covf*covf', :L), svd(covf), corr)
 end
 
-PCA(re::ReMat, corr::Bool=true) = PCA(re.λ, corr)
-
 function Base.getproperty(pca::PCA, s::Symbol)
     if s == :cumvar
         cumvv = cumsum(abs2.(pca.sv.S))
@@ -181,7 +175,6 @@ function Base.getproperty(pca::PCA, s::Symbol)
         getfield(pca, s)
     end
 end
-
 
 Base.propertynames(pca::PCA, private = false) = (
     :covcor,

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -160,7 +160,7 @@ struct PCA{T<:AbstractFloat}
     corr::Bool
 end
 
-function PCA(covfac::AbstractMatrix, corr::Bool=true)
+function PCA(covfac::AbstractMatrix; corr::Bool=true)
     covf = corr ? rownormalize!(copy(covfac)) : copy(covfac)
     PCA(Symmetric(covf*covf', :L), svd(covf), corr)
 end

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -23,7 +23,7 @@ using DataFrames, Feather, LinearAlgebra, MixedModels, Test
     @test isnan(gm1.σ)
     @test length(gm1.y) == size(gm1.X, 1)
     @test :θ in propertynames(gm0)
-    @testset "GLMM rePCA"
+    @testset "GLMM rePCA" begin
         @test length(MixedModels.PCA(gm0)) == 1
         @test length(MixedModels.rePCA(gm0)) == 1
         @test length(gm0.rePCA) == 1

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -23,6 +23,11 @@ using DataFrames, Feather, LinearAlgebra, MixedModels, Test
     @test isnan(gm1.σ)
     @test length(gm1.y) == size(gm1.X, 1)
     @test :θ in propertynames(gm0)
+    @testset "GLMM rePCA"
+        @test length(MixedModels.PCA(gm0)) == 1
+        @test length(MixedModels.rePCA(gm0)) == 1
+        @test length(gm0.rePCA) == 1
+    end
     # gm0.βθ = vcat(gm0.β, gm0.theta)
     # the next three values are not well defined in the optimization
     #@test isapprox(logdet(gm1), 75.7217, atol=0.1)

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -236,7 +236,7 @@ end
         @test length(fmnc.rePCA) == 1
         @test fmnc.rePCA.subj == [0.5, 1.0]
         @test MixedModels.PCA(fmnc).subj.loadings == I(2)
-        @test show(IOBuffer(), MixedModels.PCA(fmnc))
+        @test show(IOBuffer(), MixedModels.PCA(fmnc)) === nothing
     end
 
     fit!(fmnc)

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -159,7 +159,11 @@ end
     resid1 = residuals(fm1);
     @test size(resid1) == (73421, )
     @test first(resid1) ≈ 1.82124 atol=0.00001
-    @test length(fm1.rePCA) == 3
+
+    @testset "PCA" begin
+        @test length(fm1.rePCA) == 3
+        @test length(MixedModels.PCA(fm1)) == 3
+    end
 
     fm2 = fit!(LinearMixedModel(@formula(y ~ 1 + service*dept + (1|s) + (1|d)), insteval))
     @test objective(fm2) ≈ 237585.5534151694 atol=0.001
@@ -227,6 +231,12 @@ end
     @test size(fmnc) == (180,2,36,1)
     @test fmnc.θ == ones(2)
     @test lowerbd(fmnc) == zeros(2)
+
+    @testset "zerocorr PCA" begin
+        @test length(fmnc.rePCA) == 1
+        @test fmnc.rePCA.subj == [0.5, 1.0]
+        @test MixedModels.PCA(fmnc).subj.loadings == I(2)
+    end
 
     fit!(fmnc)
 

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -236,6 +236,7 @@ end
         @test length(fmnc.rePCA) == 1
         @test fmnc.rePCA.subj == [0.5, 1.0]
         @test MixedModels.PCA(fmnc).subj.loadings == I(2)
+        @test show(IOBuffer(), MixedModels.PCA(fmnc))
     end
 
     fit!(fmnc)


### PR DESCRIPTION
Questions:

- [x] How does the `show` method for `PCA` with all of its extra parameters look? Should some of those be renamed?
- [x] Related to that: how are the properties for that?
- [x] Should we have a function that returns a NamedTuple of the full PCA struct for each grouping variable?
- [x] Related to that: how is the API for `rePCA`? I'm not sure how I feel about `loadings`
- [x] Related to that: should `corr` be a named argument?

@dmbates Note that this has been rebased onto current `#master`, which is why it's in my fork, but if you're mostly okay with the changes, I'll force push onto the main repo's `correlationPCA` branch.