### PR TITLE
GLMM dispersion and dof_residual

### DIFF
--- a/test/fit.jl
+++ b/test/fit.jl
@@ -21,7 +21,7 @@ end
 end
 
 @testset "Normal Distribution GLMM" begin
-    @test_broken(isa(fit(MixedModel, @formula(yield ~ 1 + (1|batch)), MixedModels.dataset(:dyestuff),
-                         Normal(), LogLink),
-                     GeneralizedLinearMixedModel))
+    @test isa(fit(MixedModel, @formula(yield ~ 1 + (1|batch)), MixedModels.dataset(:dyestuff),
+                         Normal(), SqrtLink()),
+                     GeneralizedLinearMixedModel)
 end


### PR DESCRIPTION
This adds/fixes methods for  `GLM.dispersion` and `StatsBase.dof_residual` for `GeneralizedLinearMixedModel` (closes #248 and potentially #206).

Questions from late-night coding confusion:
- [x] The dispersion is just calculated as it would be in a GLM. Is this correct? 
- [x]  Residual degrees of freedom is done using the naive formula (n observation - model degrees of freedom). Is this correct?
- [x] If that is correct, then I'm not sure that `dof_residual(::LinearMixedModel)` is correct. It delivers the right answer for (its use in) the evaluation of the objective, but I don't think that the residual degree of freedom should match the number of observations nor be dependent on the fitting criterion (ML vs. REML). [`lme4` just uses the (nobs - model.df) formula](https://github.com/lme4/lme4/blob/bdf54de8298ecd505173801076ff00623e95d5eb/R/lmer.R#L1047). 

Here some samples that make me doubt myself.

# Gaussian with Non Identity Link

```julia
julia> using MixedModels, RCall
julia> glmm = GeneralizedLinearMixedModel(@formula(yield ~ 1 + (1|batch)), MixedModels.dataset(:dyestuff),Normal(),SqrtLink())
Generalized Linear Mixed Model fit by maximum likelihood (nAGQ = 1)
  yield ~ 1 + (1 | batch)
  Distribution: Normal{Float64}
  Link: SqrtLink()

  Deviance: 115249.4629

Variance components:
            Column    Variance  Std.Dev. 
batch    (Intercept)  1961.0615 44.283874
Residual              4266.2037 65.316183
 Number of obs: 30; levels of grouping factors: 6

Fixed-effects parameters:
──────────────────────────────────────────────────
             Estimate  Std.Error  z value  P(>|z|)
──────────────────────────────────────────────────
(Intercept)   39.0832    18.0791     2.16   0.0306
──────────────────────────────────────────────────
R> glmer(Yield ~ 1 + (1|Batch), data=Dyestuff, family=gaussian(link="sqrt"))
Generalized linear mixed model fit by maximum likelihood (Laplace
  Approximation) [glmerMod]
 Family: gaussian  ( sqrt )
Formula: Yield ~ 1 + (1 | Batch)
   Data: Dyestuff
      AIC       BIC    logLik  deviance  df.resid 
 381.4231  385.6267 -187.7115  375.4231        27 
Random effects:
 Groups   Name        Std.Dev.
 Batch    (Intercept) 24.49   
 Residual             44.29   
Number of obs: 30, groups:  Batch, 6
Fixed Effects:
(Intercept)  
      39.08 
```
(Note that we can't compare the deviance here because of #206 and lme4/lme4#375.)

It's a bit odd that the residual std. dev. in the lme4 fit matches the `batch` std. dev. in the MixedModels fit.

# Gamma model

I was curious whether this was a pecularity of Gaussians with non-identity link, so I tried a dumb model:
```julia
julia> kb07 = MixedModels.dataset(:kb07)
julia> gamma = fit(MixedModel,@formula(rt_raw ~ 1 + spkr*prec*load + (1+spkr+prec+load|subj)), kb07, Gamma(), LogLink())
Generalized Linear Mixed Model fit by maximum likelihood (nAGQ = 1)
  rt_raw ~ 1 + spkr + prec + load + spkr & prec + spkr & load + prec & load + spkr & prec & load + (1 + spkr + prec + load | subj)
  Distribution: Gamma{Float64}
  Link: LogLink()

  Deviance: 655.4913

Variance components:
             Column       Variance     Std.Dev.    Corr.
subj     (Intercept)     0.1382712720 0.371848453
         spkr: old       0.1382715354 0.371848807 -0.00
         prec: maintain  0.1382715355 0.371848807 -0.00  0.00
         load: yes       0.0013793501 0.037139603 -0.00  0.00  0.00
Residual                 0.1371768891 0.370373985
 Number of obs: 1789; levels of grouping factors: 56

Fixed-effects parameters:
────────────────────────────────────────────────────────────────────────────────
                                           Estimate  Std.Error  z value  P(>|z|)
────────────────────────────────────────────────────────────────────────────────
(Intercept)                              7.7793      0.0555826   139.96   <1e-99
spkr: old                                0.068266    0.0608828     1.12   0.2622
prec: maintain                          -0.301492    0.0608828    -4.95   <1e-6 
load: yes                                0.0877345   0.0355276     2.47   0.0135
spkr: old & prec: maintain              -0.0682468   0.0497819    -1.37   0.1704
spkr: old & load: yes                    0.00985952  0.0497207     0.20   0.8428
prec: maintain & load: yes              -0.0423475   0.0497207    -0.85   0.3944
spkr: old & prec: maintain & load: yes   0.0765511   0.0703376     1.09   0.2764
────────────────────────────────────────────────────────────────────────────────

julia> @rput kb07;
# this next step takes a while ....
R> glmer(rt_raw ~ 1 + spkr*prec*load + (1+spkr+prec+load|subj), kb07, family=Gamma(link="log"))
┌ Warning: RCall.jl: Warning in checkConv(attr(opt, "derivs"), opt$par, ctrl = control$checkConv,  :
│   Model failed to converge with max|grad| = 0.00332188 (tol = 0.001, component 1)
└ @ RCall ~/.julia/packages/RCall/g7dhB/src/io.jl:113
Generalized linear mixed model fit by maximum likelihood (Laplace
  Approximation) [glmerMod]
 Family: Gamma  ( log )
Formula: rt_raw ~ 1 + spkr * prec * load + (1 + spkr + prec + load | subj)
   Data: kb07
      AIC       BIC    logLik  deviance  df.resid 
 28720.41  28824.71 -14341.20  28682.41      1770 
Random effects:
 Groups   Name         Std.Dev. Corr             
 subj     (Intercept)  0.1744                    
          spkrold      0.1203   -0.36            
          precmaintain 0.1327   -0.61  0.13      
          loadyes      0.1141   -0.44  0.26  0.08
 Residual              0.3916                    
Number of obs: 1789, groups:  subj, 56
Fixed Effects:
                 (Intercept)                       spkrold  
                     7.74677                       0.07344  
                precmaintain                       loadyes  
                    -0.29274                       0.08844  
        spkrold:precmaintain               spkrold:loadyes  
                    -0.07189                      -0.00706  
        precmaintain:loadyes  spkrold:precmaintain:loadyes  
                    -0.03788                       0.08865  
convergence code 0; 1 optimizer warnings; 0 lme4 warnings 
```
Somewhat closer, despite the convergence warning. So maybe it is something about the Gaussian case.