### PR TITLE
add docstring for MixedModel supertype that points to concrete terms

### DIFF
--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -109,6 +109,13 @@ export @formula,
 
 import Base: ==, *
 
+"""
+    MixedModel
+
+Abstract type for mixed models.  MixedModels.jl implements two subtypes:
+`LinearMixedModel` and `GeneralizedLinearMixedModel`.  See the documentation for
+each for more details.
+"""
 abstract type MixedModel{T} <: StatsModels.RegressionModel end # model with fixed and random effects
 
 function __init__()

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -115,6 +115,13 @@ import Base: ==, *
 Abstract type for mixed models.  MixedModels.jl implements two subtypes:
 `LinearMixedModel` and `GeneralizedLinearMixedModel`.  See the documentation for
 each for more details.
+
+This type is primarily used for dispatch in `fit`.  Without a distribution and
+link function specified, a `LinearMixedModel` will be fit.  When a
+distribution/link function is provided, a `GeneralizedLinearModel` is fit,
+unless that distribution is `Normal` and the link is `IdentityLink`, in which
+case the resulting GLMM would be equivalent to a `LinearMixedModel` anyway and
+so the simpler, equivalent `LinearMixedModel` will be fit instead.
 """
 abstract type MixedModel{T} <: StatsModels.RegressionModel end # model with fixed and random effects
 


### PR DESCRIPTION
People often look for help on `MixedModel`.  This adds a pointer to
`LinearMixedModel` and `GeneralizedLinearMixedModel` in the docstring.