### PR TITLE
fix value-preserving zerocorr!

### DIFF
--- a/src/remat.jl
+++ b/src/remat.jl
@@ -554,8 +554,8 @@ vsize(A::ReMat{T,S}) where {T,S} = S
 
 function zerocorr!(A::ReMat{T}) where {T}
     λ = A.λ
-    A.inds = intersect(A.inds, diagind(λ))
     # zero out all entries not on the diagonal
     λ[setdiff(A.inds, diagind(λ))] .= 0
+    A.inds = intersect(A.inds, diagind(λ))
     A
 end


### PR DESCRIPTION
I take the blame for this.

But note that the refit route will often give slightly different results (such is life with nonlinear optimization...):
```julia
using MixedModels

kb = fit(MixedModel, @formula(rt_raw ~ 1 + spkr * prec * load + (1 + spkr * prec * load | subj) + (1 + spkr * prec* load |item)), MixedModels.dataset("kb07"));
kbzc = fit(MixedModel, @formula(rt_raw ~ 1 + spkr * prec * load + (1 + spkr * prec * load | subj) + zerocorr(1 + spkr * prec* load |item)), MixedModels.dataset("kb07"));
kbzc_refit = fit!(zerocorr!(deepcopy(kb), [:item]));
```

```julia
julia> kbzc.optsum
Initial parameter vector: [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0  …  0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
Initial objective value:  30268.52732836507

Optimizer (from NLopt):   LN_BOBYQA
Lower bounds:             [0.0, -Inf, -Inf, -Inf, -Inf, -Inf, -Inf, -Inf, 0.0, -Inf  …  -Inf, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
ftol_rel:                 1.0e-12
ftol_abs:                 1.0e-8
xtol_rel:                 0.0
xtol_abs:                 [1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10  …  1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10]
initial_step:             [0.75, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.75, 1.0  …  1.0, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75]
maxfeval:                 -1

Function evaluations:     2231
Final parameter vector:   [0.3998989765931153, -0.0008938475210819249, -0.2006550277831373, 0.013708563909373878, 0.0070652407138793085, 0.28485272005437673, -0.0065209001418908745, -0.29898710614800417, 0.4485551444694296, 0.1041039377127361  …  -0.00014855350832248374, 0.0, 0.6741828789065242, 0.0, 0.6239072046688013, 0.0, 0.1190031474286591, 0.0010574572081512525, 0.0, 0.0]
Final objective value:    29669.46226910433
Return code:              FTOL_REACHED

julia> kbzc_refit.optsum
Initial parameter vector: [0.4242365953032411, -0.032183890846707724, -0.22147228471059105, 0.027144065277263114, -0.05231184346833731, 0.31241874067820435, 0.034791336635986735, -0.32101500159724894, 0.49239305154707447, 0.11072175406750547  …  -6.976817680662094e-6, 0.0, 0.6850513484100353, 0.2963114992328519, 0.1751107886899463, 0.0, 0.20281513576574595, 0.0014619694178925444, 0.0, 0.0]
Initial objective value:  29742.168961358435

Optimizer (from NLopt):   LN_BOBYQA
Lower bounds:             [0.0, -Inf, -Inf, -Inf, -Inf, -Inf, -Inf, -Inf, 0.0, -Inf  …  -Inf, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
ftol_rel:                 1.0e-12
ftol_abs:                 1.0e-8
xtol_rel:                 0.0
xtol_abs:                 [1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10  …  1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10, 1.0e-10]
initial_step:             [0.31817744647743085, -0.032183890846707724, -0.22147228471059105, 0.027144065277263114, -0.05231184346833731, 0.31241874067820435, 0.034791336635986735, -0.32101500159724894, 0.36929478866030585, 0.11072175406750547  …  -6.976817680662094e-6, 1.0, 0.5137885113075265, 0.2222336244246389, 0.13133309151745973, 1.0, 0.15211135182430946, 0.0010964770634194084, 1.0, 1.0]
maxfeval:                 -1

Function evaluations:     1954
Final parameter vector:   [0.4051029801426724, -0.015827866502107147, -0.21133907395963686, 0.033193298237226124, -0.008307203957640476, 0.30356104196900763, 0.013025131534406438, -0.32452053022154603, 0.45591838309209803, 0.10926792692817446  …  -6.4918553881910856e-6, 0.0, 0.6747776428188323, 0.0, 0.6249082333180387, 0.0, 0.11857084132947251, 0.0015743432728840556, 0.0, 0.0]
Final objective value:    29669.492778260657
Return code:              FTOL_REACHED
```