### PR TITLE
Add stderror! method, distinguish coef and fixef

### DIFF
--- a/src/femat.jl
+++ b/src/femat.jl
@@ -77,4 +77,11 @@ LinearAlgebra.mul!(R::StridedVecOrMat{T}, A::FeMat{T}, B::StridedVecOrMat{T}) wh
 LinearAlgebra.mul!(C, adjA::Adjoint{T,<:FeMat{T}}, B::FeMat{T}) where {T} =
     mul!(C, fullrankwtx(adjA.parent)', fullrankwtx(B))
 
+"""
+    isfullrank(A::FeMat)
+
+Does `A` have full column rank?
+"""
+isfullrank(A::FeMat) = A.rank == length(A.piv)
+
 nθ(A::FeMat) = 0

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -53,7 +53,9 @@ struct GeneralizedLinearMixedModel{T<:AbstractFloat} <: MixedModel{T}
     mult::Vector{T}
 end
 
-StatsBase.coefnames(m::GeneralizedLinearMixedModel) = fixefnames(m, false)
+StatsBase.coefnames(m::GeneralizedLinearMixedModel) = coefnames(m.LMM)
+
+StatsBase.coeftable(m::GeneralizedLinearMixedModel) = coeftable(m.LMM)
 
 
 """

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -382,7 +382,7 @@ StatsBase.fitted(m::LinearMixedModel{T}) where {T} = fitted!(Vector{T}(undef, no
 
 Overwrite `v` with the pivoted fixed-effects coefficients of model `m`
 
-For full rank models the length of `v` must be the rank of `X`.  For rank-deficient models
+For full-rank models the length of `v` must be the rank of `X`.  For rank-deficient models
 the length of `v` can be the rank of `X` or the number of columns of `X`.  In the latter
 case the calculated coefficients are padded with -0.0 out to the number of columns.
 """
@@ -824,6 +824,10 @@ function stderror!(v::AbstractVector{T}, m::LinearMixedModel{T}) where {T}
     end
     invpermute!(v, fetrm(m).piv)
     v
+end
+
+function StatsBase.stderror(m::LinearMixedModel{T}) where {T}
+    stderror!(similar(fetrm(m).piv, T), m)
 end
 
 """


### PR DESCRIPTION
The docs should be updated to indicate that `coef` always refers to the full coefficient vector, as does `stderror` and `fixef` refers to the truncated coefficient vector.  Furthermore this extends to associated functions like `coefnames` and `fixefnames`.  However, I think it is better to do this in the version from #283