### PR TITLE
Take the dispersion into account for GLMM familes with a dispersion param

### DIFF
--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -584,7 +584,7 @@ function updateη!(m::GeneralizedLinearMixedModel)
     m
 end
 
-varest(m::GeneralizedLinearMixedModel{T}) where {T} = one(T)
+varest(m::GeneralizedLinearMixedModel{T}) where {T} = dispersion_parameter(m) ? dispersion(m) : one(T)
 
             # delegate GLMM method to LMM field
 for f in (


### PR DESCRIPTION
Closes #206 

- [x] `varest`
- [ ] `deviance`
- [ ] `loglikelihood`
- [ ] export all the usual links
    - [ ] identity
    - [ ] sqrt
    - [ ] log
    - [ ] inverse
    - [ ] probit
    - [ ] logit
- [ ] tests for this functionality in all families
    - [ ] Bernoulli
    - [ ] Binomial 
    - [ ] Gamma 
    - [ ] Gaussian with non-identity link
    - [ ] InverseGaussian
    - [ ] Poisson 
 
Note (to self) that some distributions (e.g. Gamma) require changing the linear predictor + dispersion into a different parameterization (e.g. shape, scale).