### PR TITLE
test on Julia 1.5 in Future workflow

### DIFF
--- a/.github/workflows/Future.yml
+++ b/.github/workflows/Future.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [nightly]
+        julia-version: [1.5, nightly]
         julia-arch: [x64]
         os: [ubuntu-18.04]
     steps:


### PR DESCRIPTION
Now that there's a Julia 1.5 beta, let's see if we can test on it in GitHub Actions.