### PR TITLE
restore the use of views not @simd workarounds

### DIFF
--- a/.github/workflows/Future.yml
+++ b/.github/workflows/Future.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [nightly]
+        julia-version: [1.5.0-beta1, nightly]
         julia-arch: [x64]
         os: [ubuntu-18.04]
     steps:

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -3,10 +3,10 @@ git-tree-sha1 = "6614babc98083a65c25b7ec1ef2e38b345de65c9"
 lazy = true
 
     [[TestData.download]]
-    sha256 = "e85dc5f76251707034ff1e086775349650d81ddebabba67c0f065143c5cee134"
+    sha256 = "92e1d57966e6d4716d9925450b4a100d923e3df4c40060d110860cf968ec6559"
     # when updating this, making sure to include the version (change to new) and
     # displayName (don't change) because the default link always points to the newest
     # (and so will not match the SHA for users not yet on the most recent version)
     # and Julia invokes wget without using HTTP metadata, so we need the link
     # to end with the right extension unless we want to fall back to gzip compression
-    url = "https://osf.io/uyb5j/download'?'version=2'&'displayName=data.tar.xz"
+    url = "https://osf.io/pcjk6/download"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -3,10 +3,10 @@ git-tree-sha1 = "6614babc98083a65c25b7ec1ef2e38b345de65c9"
 lazy = true
 
     [[TestData.download]]
-    sha256 = "e85dc5f76251707034ff1e086775349650d81ddebabba67c0f065143c5cee134"
+    sha256 = "92e1d57966e6d4716d9925450b4a100d923e3df4c40060d110860cf968ec6559"
     # when updating this, making sure to include the version (change to new) and
     # displayName (don't change) because the default link always points to the newest
     # (and so will not match the SHA for users not yet on the most recent version)
     # and Julia invokes wget without using HTTP metadata, so we need the link
     # to end with the right extension unless we want to fall back to gzip compression
-    url = "https://osf.io/uyb5j/download?version=2&displayName=data.tar.xz"
+    url = "https://osf.io/pcjk6/download"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,7 +1,12 @@
 [TestData]
-git-tree-sha1 = "d3fe9d4e2e432b1ec1d8f0a80cf778a94f81e7c6"
+git-tree-sha1 = "6614babc98083a65c25b7ec1ef2e38b345de65c9"
 lazy = true
 
     [[TestData.download]]
-    sha256 = "7bb283955521bd513cdd0a8c57e8440b3d40450ba338769806cf4fba0b9662f4"
-    url = "https://osf.io/uyb5j/download"
+    sha256 = "e85dc5f76251707034ff1e086775349650d81ddebabba67c0f065143c5cee134"
+    # when updating this, making sure to include the version (change to new) and
+    # displayName (don't change) because the default link always points to the newest
+    # (and so will not match the SHA for users not yet on the most recent version)
+    # and Julia invokes wget without using HTTP metadata, so we need the link
+    # to end with the right extension unless we want to fall back to gzip compression
+    url = "https://osf.io/uyb5j/download?version=2&displayName=data.tar.xz"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,7 +1,7 @@
 [TestData]
-git-tree-sha1 = "9d575764bc1c1a7860c34c5b153251e5f2ee6704"
+git-tree-sha1 = "d3fe9d4e2e432b1ec1d8f0a80cf778a94f81e7c6"
 lazy = true
 
     [[TestData.download]]
-    sha256 = "0b63ae3e9e457ee4b33482d3bf8cc7f20c8ed7c8b2c863af311ba0944c6d46e4"
-    url = "https://ndownloader.figshare.com/files/21085968"
+    sha256 = "7bb283955521bd513cdd0a8c57e8440b3d40450ba338769806cf4fba0b9662f4"
+    url = "https://osf.io/uyb5j/download"

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -3,10 +3,10 @@ git-tree-sha1 = "6614babc98083a65c25b7ec1ef2e38b345de65c9"
 lazy = true
 
     [[TestData.download]]
-    sha256 = "92e1d57966e6d4716d9925450b4a100d923e3df4c40060d110860cf968ec6559"
+    sha256 = "e85dc5f76251707034ff1e086775349650d81ddebabba67c0f065143c5cee134"
     # when updating this, making sure to include the version (change to new) and
     # displayName (don't change) because the default link always points to the newest
     # (and so will not match the SHA for users not yet on the most recent version)
     # and Julia invokes wget without using HTTP metadata, so we need the link
     # to end with the right extension unless we want to fall back to gzip compression
-    url = "https://osf.io/pcjk6/download"
+    url = "https://osf.io/uyb5j/download'?'version=2'&'displayName=data.tar.xz"

--- a/src/arraytypes.jl
+++ b/src/arraytypes.jl
@@ -5,14 +5,6 @@ Homogeneous block diagonal matrices.  `k` diagonal blocks each of size `m×m`
 """
 struct UniformBlockDiagonal{T} <: AbstractMatrix{T}
     data::Array{T,3}
-    facevec::Vector{SubArray{T,2,Array{T,3}}}
-end
-
-function UniformBlockDiagonal(dat::Array{T,3}) where {T}
-    UniformBlockDiagonal(
-        dat,
-        SubArray{T,2,Array{T,3}}[view(dat, :, :, i) for i = 1:size(dat, 3)],
-    )
 end
 
 function Base.axes(A::UniformBlockDiagonal)

--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -47,11 +47,11 @@ function LinearAlgebra.ldiv!(
 ) where {T}
     A = adjA.parent
     length(B) == size(A, 2) || throw(DimensionMismatch(""))
-    m, n, k = size(A.data.data)
-    fv = A.data.facevec
+    Adat = A.data.data
+    m, n, k = size(Adat)
     bb = reshape(B, (n, k))
-    for j = 1:k
-        ldiv!(adjoint(LowerTriangular(fv[j])), view(bb, :, j))
+    for j in axes(Adat, 3)
+        ldiv!(adjoint(LowerTriangular(view(Adat, :, :, j))), view(bb, :, j))
     end
     B
 end
@@ -77,12 +77,16 @@ function LinearAlgebra.rdiv!(
     B::Adjoint{T,<:LowerTriangular{T,UniformBlockDiagonal{T}}},
 ) where {T,S,P}
     Bpd = B.parent.data
-    j, k, l = size(Bpd.data)
+    Bdat = Bpd.data
+    j, k, l = size(Bdat)
     cbpt = A.colblkptr
     nzv = A.cscmat.nzval
     P == j == k && length(cbpt) == (l + 1) || throw(DimensionMismatch(""))
-    for (j, f) in enumerate(Bpd.facevec)
-        rdiv!(reshape(view(nzv, cbpt[j]:(cbpt[j+1]-1)), :, P), adjoint(LowerTriangular(f)))
+    for j in axes(Bdat, 3)
+        rdiv!(
+            reshape(view(nzv,cbpt[j]:(cbpt[j+1]-1)),:,P),
+            adjoint(LowerTriangular(view(Bdat,:,:,j)))
+            )
     end
     A
 end

--- a/src/linalg/cholUnblocked.jl
+++ b/src/linalg/cholUnblocked.jl
@@ -32,8 +32,9 @@ function cholUnblocked!(A::StridedMatrix{T}, ::Type{Val{:L}}) where {T<:BlasFloa
 end
 
 function cholUnblocked!(D::UniformBlockDiagonal, ::Type{Val{:L}})
-    for f in D.facevec
-        cholUnblocked!(f, Val{:L})
+    Ddat = D.data
+    for k in axes(Ddat, 3)
+        cholUnblocked!(view(Ddat, :, :, k), Val{:L})
     end
     D
 end

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -114,15 +114,15 @@ function rankUpdate!(
     Ac = A.cscmat
     cp = Ac.colptr
     all(diff(cp) .== S) || throw(ArgumentError("Each column of A must contain exactly S nonzeros"))
-    j, k, l = size(C.data.data)
+    Cdat = C.data.data
+    j, k, l = size(Cdat)
     S == j == k && div(Ac.m, S) == l ||
-    throw(DimensionMismatch("div(A.cscmat.m, S) ≠ length(C.data.facevec)"))
+    throw(DimensionMismatch("div(A.cscmat.m, S) ≠ size(C.data.data, 3)"))
     nz = Ac.nzval
     rv = Ac.rowval
-    Cdf = C.data.facevec
     for j = 1:Ac.n
         nzr = nzrange(Ac, j)
-        BLAS.syr!('L', α, view(nz, nzr), Cdf[div(rv[last(nzr)], S)])
+        BLAS.syr!('L', α, view(nz, nzr), view(Cdat, :, :, div(rv[last(nzr)], S)))
     end
     C
 end

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -444,10 +444,12 @@ end
 function scaleinflate!(Ljj::UniformBlockDiagonal{T}, Λj::ReMat{T,S}) where {T,S}
     λ = Λj.λ
     dind = diagind(S, S)
-    for f in Ljj.facevec
+    Ldat = Ljj.data
+    for k in axes(Ldat, 3)
+        f = view(Ldat, :, :, k)
         lmul!(λ', rmul!(f, λ))
         for i in dind
-            f[i] += one(T)
+            f[i] += one(T)  # inflate diagonal
         end
     end
     Ljj

--- a/test/UniformBlockDiagonal.jl
+++ b/test/UniformBlockDiagonal.jl
@@ -22,7 +22,7 @@ const LMM = LinearMixedModel
         @test size(ex22, 1) == 6
         @test size(ex22, 2) == 6
         @test size(ex22.data) == (2, 2, 3)
-        @test length(ex22.facevec) == 3
+    #    @test length(ex22.facevec) == 3
         @test size(vf1) == (12, 6)
         @test size(vf2) == (12, 4)
         @test size(prd) == (4, 6)
@@ -39,17 +39,17 @@ const LMM = LinearMixedModel
     end
 
     @testset "facevec" begin
-        @test ex22.facevec[3] == reshape(9:12, (2,2))
+        @test view(ex22.data, :, :, 3) == reshape(9:12, (2,2))
     end
 
     @testset "scaleinflate" begin
         MixedModels.scaleinflate!(copyto!(Lblk, ex22), vf1)
-        @test Lblk.facevec[1] == [2. 3.; 2. 5.]
+        @test view(Lblk.data, :, :, 1) == [2. 3.; 2. 5.]
         setθ!(vf1, [1.,1.,1.])
         Λ = vf1.λ
         MixedModels.scaleinflate!(copyto!(Lblk, ex22), vf1)
-        target = Λ'ex22.facevec[1]*Λ + I
-        @test Lblk.facevec[1] == target
+        target = Λ'view(ex22.data, :, :, 1)*Λ + I
+        @test view(Lblk.data, :, :, 1) == target
     end
 
     @testset "updateL" begin

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -271,11 +271,11 @@ end
     @test isa(A11, UniformBlockDiagonal{Float64})
     @test isa(fm.L[Block(1, 1)], UniformBlockDiagonal{Float64})
     @test size(A11) == (36, 36)
-    a11 = A11.facevec[1]
+    a11 = view(A11.data, :, :, 1)
     @test a11 == [10. 45.; 45. 285.]
-    @test length(A11.facevec) == 18
+    @test size(A11.data, 3) == 18
     λ = first(fm.λ)
-    b11 = LowerTriangular(fm.L[Block(1, 1)].facevec[1])
+    b11 = LowerTriangular(view(fm.L[Block(1, 1)].data, :, :, 1))
     @test b11 * b11' ≈ λ'a11*λ + I rtol=1e-5
     @test count(!iszero, Matrix(fm.L[Block(1, 1)])) == 18 * 4
     @test rank(fm) == 2

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -327,8 +327,8 @@ end
 
     @testset "zerocorr PCA" begin
         @test length(fmnc.rePCA) == 1
-        @test fmnc.rePCA.subj == [0.5, 1.0]
-        @test MixedModels.PCA(fmnc).subj.loadings == I(2)
+        @test fmnc.rePCA.subj ≈ [0.5, 1.0]
+        @test_broken MixedModels.PCA(fmnc).subj.loadings ≈ I(2)
         @test show(IOBuffer(), MixedModels.PCA(fmnc)) === nothing
     end
 

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -328,7 +328,7 @@ end
     @testset "zerocorr PCA" begin
         @test length(fmnc.rePCA) == 1
         @test fmnc.rePCA.subj ≈ [0.5, 1.0]
-        @test_broken MixedModels.PCA(fmnc).subj.loadings ≈ I(2)
+        @test any(Ref(fmnc.PCA.subj.loadings) .≈ (I(2), I(2)[:, [2,1]]))
         @test show(IOBuffer(), MixedModels.PCA(fmnc)) === nothing
     end
 


### PR DESCRIPTION
- replace and remove code to by-pass creation of views in some linear algebra operations, especially those related to `UniformBlockDiagonal` arrays and some pre- and post-multiplications by a repeated block diagonal array.
- prior to Julia v1.5.0 expressing these operations using views required a lot of allocations and garbage collection.  v1.5.0 does away with these allocations.  Many thanks to those who made this happen.