### PR TITLE
Add and use parmap field.

### DIFF
--- a/src/femat.jl
+++ b/src/femat.jl
@@ -83,5 +83,3 @@ LinearAlgebra.mul!(C, adjA::Adjoint{T,<:FeMat{T}}, B::FeMat{T}) where {T} =
 Does `A` have full column rank?
 """
 isfullrank(A::FeMat) = A.rank == length(A.piv)
-
-nθ(A::FeMat) = 0

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -356,6 +356,7 @@ function GeneralizedLinearMixedModel(
             LMM.formula,
             LMM.allterms,
             fill!(similar(y), 1),
+            LMM.parmap,
             LMM.A,
             LMM.L,
             LMM.optsum,

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -319,6 +319,7 @@ end
     @test size(fmnc) == (180,2,36,1)
     @test fmnc.θ == [fm.θ[1], fm.θ[3]]
     @test lowerbd(fmnc) == zeros(2)
+    @test_throws DimensionMismatch MixedModels.getθ!(fm.θ, fmnc)
 
     fmnc = models(:sleepstudy)[2]
     @test size(fmnc) == (180,2,36,1)


### PR DESCRIPTION
The `parmap` field in a `LinearMixedModel` is a vector of triples of the form `(term, row, column)` giving the mapping from the elements of the θ parameter vector to the positions in the λ matrices for each random-effects term.  Storing this as a separate field allows for cleaner logic in methods for `nθ`, `setθ!`, and `getθ!`.