### PR TITLE
Rank update

### DIFF
--- a/src/arraytypes.jl
+++ b/src/arraytypes.jl
@@ -92,3 +92,15 @@ function Base.copyto!(L::BlockedSparse{T}, A::SparseMatrixCSC{T}) where {T}
     copyto!(nonzeros(L.cscmat), nonzeros(A))
     L
 end
+
+LinearAlgebra.rdiv!(A::BlockedSparse, B::Diagonal) = rdiv!(A.cscmat, B)
+
+function LinearAlgebra.mul!(
+    C::BlockedSparse{T,1,P},
+    A::SparseMatrixCSC{T,Ti},
+    adjB::Adjoint{T,BlockedSparse{T,P,1}},
+    α,
+    β
+    ) where {T,P,Ti}
+    mul!(C.cscmat, A, adjB.parent.cscmat', α, β)
+end

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -11,58 +11,25 @@ The order of the arguments
 """
 function rankUpdate! end
 
-function rankUpdate!(
-    C::AbstractMatrix{T},
-    A::AbstractMatrix{T},
-    α=true,
-    β=true) where {T}
-
-    m, n = size(A)
-    m == size(C, 2) || throw(DimensionMismatch(""))
-    @info "it is surprising that this function is called - please report a use case as a MixedModels issue"
-    @warn "using generic method, this will be slower than usual"
-
-    A = A'A
-
-    for (i, el) in enumerate(C)
-        C[i] = β * el + α * A[i]
-    end
-    C
-end
-
-function rankUpdate!(
-    C::HermOrSym{T,S},
-    a::StridedVector{T},
-    α = true,
-) where {T<:BlasReal,S<:StridedMatrix}
+function rankUpdate!(C::HermOrSym{T,S}, a::StridedVector{T}, α, β) where {T,S}
+    isone(β) || throw(ArgumentError("isone(β) is false"))
     BLAS.syr!(C.uplo, T(α), a, C.data)
     C  ## to ensure that the return value is HermOrSym
 end
 
-function rankUpdate!(
-    C::HermOrSym{T,S},
-    A::StridedMatrix{T},
-    α = true,
-    β = true,
-) where {T<:BlasReal,S<:StridedMatrix}
+function rankUpdate!(C::HermOrSym{T,S}, A::StridedMatrix{T}, α, β) where {T,S}
     BLAS.syrk!(C.uplo, 'N', T(α), A, T(β), C.data)
     C
 end
 
-function rankUpdate!(
-    C::HermOrSym{T,Matrix{T}},
-    A::SparseMatrixCSC{T},
-    α = true,
-    β = true,
-) where {T}
-    m, n = size(A)
-    m == size(C, 2) || throw(DimensionMismatch(""))
+function rankUpdate!(C::HermOrSym{T,S}, A::SparseMatrixCSC{T}, α, β) where {T,S}
+    A.m == size(C, 2) || throw(DimensionMismatch())
     C.uplo == 'L' || throw(ArgumentError("C.uplo must be 'L'"))
     Cd = C.data
     isone(β) || rmul!(LowerTriangular(Cd), β)
     rv = rowvals(A)
     nz = nonzeros(A)
-    @inbounds for jj = 1:n
+    @inbounds for jj = 1:A.n
         rangejj = nzrange(A, jj)
         lenrngjj = length(rangejj)
         for (k, j) in enumerate(rangejj)
@@ -77,43 +44,38 @@ function rankUpdate!(
     C
 end
 
-rankUpdate!(C::HermOrSym, A::BlockedSparse, α = true, β = true) =
+function rankUpdate!(C::HermOrSym, A::BlockedSparse, α, β)
     rankUpdate!(C, sparse(A), α, β)
+end
 
-function rankUpdate!(
-    C::Diagonal{T},
-    A::SparseMatrixCSC{T},
-    α = true,
-    β = true,
-) where {T<:Number}
-    m, n = size(A)
-    dd = C.diag
-    length(dd) == m || throw(DimensionMismatch(""))
+function rankUpdate!(C::HermOrSym{T,Diagonal{T}}, A::SparseMatrixCSC{T}, α, β) where {T}
+    dd = C.data.diag
+    A.m == length(dd) || throw(DimensionMismatch())
     isone(β) || rmul!(dd, β)
     nz = nonzeros(A)
     rv = rowvals(A)
-    @inbounds for j = 1:n
-        nzr = nzrange(A, j)
-        if !isempty(nzr)
-            length(nzr) == 1 || throw(ArgumentError("A*A' has off-diagonal elements"))
-            k = nzr[1]
-            dd[rv[k]] += α * abs2(nz[k])
-        end
+    @inbounds for j = 1:A.n
+        k = only(nzrange(A, j))
+        dd[rv[k]] += α * abs2(nz[k])
     end
     C
 end
 
-rankUpdate!(C::Diagonal{T}, A::BlockedSparse{T}, α = true, β = true) where {T<:Number} =
+function rankUpdate!(C::HermOrSym{T,Diagonal{T}}, A::BlockedSparse{T}, α, β) where {T}
     rankUpdate!(C, sparse(A), α, β)
+end
 
 function rankUpdate!(
-    C::HermOrSym{T,UniformBlockDiagonal{T}},
+    C::HermOrSym{T,UniformBlockDiagonal{T}}, 
     A::BlockedSparse{T,S},
-    α = true,
+    α,
+    β,
 ) where {T,S}
     Ac = A.cscmat
     cp = Ac.colptr
-    all(diff(cp) .== S) || throw(ArgumentError("Each column of A must contain exactly S nonzeros"))
+    if any(diff(cp) .≠ S)
+        throw(ArgumentError("Each column of A must contain exactly S nonzeros"))
+    end
     Cdat = C.data.data
     j, k, l = size(Cdat)
     S == j == k && div(Ac.m, S) == l ||
@@ -127,36 +89,21 @@ function rankUpdate!(
     C
 end
 
-#=
-rankUpdate!(C::HermOrSym{T,Matrix{T}}, A::BlockedSparse{T}, α = true) where {T} =
-    rankUpdate!(C, A.cscmat, α)
-=#
+function rankUpdate!(C::HermOrSym{T,Diagonal{T}}, A::Diagonal{T}, α, β) where {T}
+    Cdiag = C.data.diag
+    if length(Cdiag) ≠ length(A.diag)
+        throw(DimensionMismatch("length(C.data.diag) ≠ length(A.diag)"))
+    end
 
-function rankUpdate!(
-    C::Diagonal{T,S},
-    A::Diagonal{T,S},
-    α::Number = true,
-    β::Number = true,
-) where {T,S}
-    length(C.diag) == length(A.diag) || throw(DimensionMismatch("length(C.diag) ≠ length(A.diag)"))
-
-    C.diag .= β .* C.diag .+ α .* abs2.(A.diag)
+    Cdiag = β .* Cdiag .+ α .* abs2.(A.diag)
     C
 end
 
-
-function rankUpdate!(
-    C::HermOrSym{T,Matrix{T}},
-    A::Diagonal{T},
-    α::Number = true,
-    β::Number = true,
-) where {T}
-    m, n = size(A)
-    m == size(C, 2) || throw(DimensionMismatch(""))
-    adiag = A.diag
-    cdata = C.data
-    for (i, a) in zip(diagind(cdata), adiag)
-        cdata[i] = β * cdata[i] + α * abs2(a)
+function rankUpdate!(C::HermOrSym{T,Matrix{T}}, A::Diagonal{T}, α, β) where {T}
+    Adiag, Cdata = A.diag, C.data
+    length(Adiag) == size(C, 2) || throw(DimensionMismatch())
+    for (i, a) in zip(diagind(Cdata), Adiag)
+        Cdata[i] = β * Cdata[i] + α * abs2(a)
     end
     C
 end

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -11,6 +11,10 @@ The order of the arguments
 """
 function rankUpdate! end
 
+function rankUpdate!(C::AbstractMatrix, a::AbstractArray, α, β)
+    error("We haven't implemented a method for $(typeof(C)), $(typeof(a)). Please file an issue on GitHub.")
+end
+
 function rankUpdate!(C::HermOrSym{T,S}, a::StridedVector{T}, α, β) where {T,S}
     isone(β) || throw(ArgumentError("isone(β) is false"))
     BLAS.syr!(C.uplo, T(α), a, C.data)
@@ -69,7 +73,7 @@ function rankUpdate!(C::HermOrSym{T,Diagonal{T}}, A::BlockedSparse{T}, α, β) w
 end
 
 function rankUpdate!(
-    C::HermOrSym{T,UniformBlockDiagonal{T}}, 
+    C::HermOrSym{T,UniformBlockDiagonal{T}},
     A::BlockedSparse{T,S},
     α,
     β,

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -96,7 +96,7 @@ function rankUpdate!(C::HermOrSym{T,Diagonal{T}}, A::Diagonal{T}, α, β) where 
         throw(DimensionMismatch("length(C.data.diag) ≠ length(A.diag)"))
     end
 
-    Cdiag = β .* Cdiag .+ α .* abs2.(A.diag)
+    Cdiag .= β .* Cdiag .+ α .* abs2.(A.diag)
     C
 end
 

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -531,7 +531,7 @@ end
 
 nθ(m::LinearMixedModel) = length(m.parmap)
 
-StatsBase.nobs(m::LinearMixedModel) = first(size(m))
+StatsBase.nobs(m::LinearMixedModel) = length(first(m.allterms).refs)
 
 """
     objective(m::LinearMixedModel)
@@ -902,9 +902,8 @@ function updateL!(m::LinearMixedModel{T}) where {T}
     end
     for j = 1:k                         # blocked Cholesky
         Ljj = L[Block(j, j)]
-        LjjH = isa(Ljj, Diagonal) ? Ljj : Hermitian(Ljj, :L)
         for jj = 1:(j-1)
-            rankUpdate!(LjjH, L[Block(j, jj)], -one(T))
+            rankUpdate!(Hermitian(Ljj, :L), L[Block(j, jj)], -one(T), one(T))
         end
         cholUnblocked!(Ljj, Val{:L})
         LjjT = isa(Ljj, Diagonal) ? Ljj : LowerTriangular(Ljj)

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -393,9 +393,14 @@ function reweight!(A::ReMat, sqrtwts::Vector)
     A
 end
 
-rmulΛ!(A::M, B::ReMat{T,1}) where{M<:AbstractMatrix{T}} where{T} = rmul!(A, only(B.λ.data))
+rmulΛ!(A::Matrix{T}, B::ReMat{T,1}) where{T} = rmul!(A, only(B.λ.data))
 
-function rmulΛ!(A::M, B::ReMat{T,S}) where {M<:AbstractMatrix{T}} where {T,S}
+function rmulΛ!(A::SparseMatrixCSC{T}, B::ReMat{T,1}) where {T}
+    rmul!(nonzeros(A), only(B.λ.data))
+    A
+end
+
+function rmulΛ!(A::Matrix{T}, B::ReMat{T,S}) where {T,S} 
     m, n = size(A)
     q, r = divrem(n, S)
     iszero(r) || throw(DimensionMismatch("size(A, 2) is not a multiple of block size"))

--- a/test/UniformBlockDiagonal.jl
+++ b/test/UniformBlockDiagonal.jl
@@ -53,7 +53,7 @@ const LMM = LinearMixedModel
     end
 
     @testset "updateL" begin
-        @test ones(2, 2) == MixedModels.rankUpdate!(Hermitian(zeros(2, 2)), ones(2))
+        @test ones(2, 2) == MixedModels.rankUpdate!(Hermitian(zeros(2, 2)), ones(2), 1., 1.)
         d3 = MixedModels.dataset(:d3)
         sch = schema(d3)
         vf1 = modelcols(apply_schema(@formula(y ~ 1 + u + (1+u|g)), sch, LMM), d3)[2][2]

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -52,6 +52,12 @@ end
     @test loglikelihood(fit!(wm1)) ≈ loglikelihood(m1)
 end
 
+@testset "rankupdate!" begin
+    x = [1 1; 1 1];
+    err = ErrorException("We haven't implemented a method for Array{Int64,2}, Array{Int64,2}. Please file an issue on GitHub.");
+    @test_throws err rankUpdate!(x, x, 1, 1);
+end
+
 #=  I don't see this testset as meaningful b/c diagonal A does not occur after amalgamation of ReMat's for the same grouping factor - D.B.
 @testset "rankupdate!" begin
     @test ones(2, 2) == rankUpdate!(Hermitian(zeros(2, 2)), ones(2))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -52,6 +52,7 @@ end
     @test loglikelihood(fit!(wm1)) ≈ loglikelihood(m1)
 end
 
+#=  I don't see this testset as meaningful b/c diagonal A does not occur after amalgamation of ReMat's for the same grouping factor - D.B.
 @testset "rankupdate!" begin
     @test ones(2, 2) == rankUpdate!(Hermitian(zeros(2, 2)), ones(2))
     d2 = Diagonal(fill(2., 2))
@@ -63,6 +64,7 @@ end
     # generic method
     @test Diagonal(fill(5.,2)) == rankUpdate!(Matrix(1. * I(2)), d2)
 end
+=#
 
 @testset "lmulλ!" begin
     levs(ng, tag='S') = string.(tag, lpad.(string.(1:ng), ndigits(ng), '0'))


### PR DESCRIPTION
Clean up `rankUpdate!` methods.  In particular use Hermitian{T, Diagonal{T, Vector{T}}} instead of branching on the diagonal case in `updateL!`.  We want to use method dispatch instead of `if` statements that I had in the code.  This should be rebased on master after #329 is merged.

Closes #290.