### PR TITLE
use weights when fitting LMM

### DIFF
--- a/test/pls.jl
+++ b/test/pls.jl
@@ -499,14 +499,16 @@ end
                      c = categorical(["H","F","K","P","P","P","D","M","I","D"]),
                      w1 = [20,40,35,12,29,25,65,105,30,75],
                      w2 = [0.04587156,0.091743119,0.080275229,0.027522936,0.066513761,0.05733945,0.149082569,0.240825688,0.068807339,0.172018349])
+
+    #= no need to fit yet another model without weights, but here are the reference values from lme4
     m1 = fit(MixedModel, @formula(a ~ 1 + b + (1|c)), data)
-    m2 = fit(MixedModel, @formula(a ~ 1 + b + (1|c)), data, wts = data.w1)
-
     @test m1.θ ≈ [0.0]
-    @test m2.θ ≈ [0.295181729258352]  atol = 1.e-4
-
     @test stderror(m1) ≈  [1.084912, 4.966336] atol = 1.e-4
-    @test stderror(m2) ≈  [0.9640167, 3.6309696] atol = 1.e-4
     @test vcov(m1) ≈ [1.177035 -4.802598; -4.802598 24.664497] atol = 1.e-4
+    =#
+
+    m2 = fit(MixedModel, @formula(a ~ 1 + b + (1|c)), data, wts = data.w1)
+    @test m2.θ ≈ [0.295181729258352]  atol = 1.e-4
+    @test stderror(m2) ≈  [0.9640167, 3.6309696] atol = 1.e-4
     @test vcov(m2) ≈ [0.9293282 -2.557527; -2.5575267 13.183940] atol = 1.e-4
 end

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -441,7 +441,7 @@ end
     # we'll have to change the test
     @test first(cov) == 1.
     @test last(cov) == 95.
-    
+
     bsamp_threaded = parametricbootstrap(MersenneTwister(1234321), 100, fm, use_threads=true)
     # even though it's bad practice with floating point, exact equality should
     # be a valid test here -- if everything is working right, then it's the exact
@@ -490,4 +490,23 @@ end
 @testset "coeftable" begin
     ct = coeftable(only(models(:dyestuff)));
     @test [3,4] == [ct.teststatcol, ct.pvalcol]
+end
+
+@testset "wts" begin
+    # example from https://github.com/JuliaStats/MixedModels.jl/issues/194
+    data = DataFrame(a = [1.55945122,0.004391538,0.005554163,-0.173029772,4.586284429,0.259493671,-0.091735715,5.546487603,0.457734831,-0.030169602],
+                     b = [0.24520519,0.080624178,0.228083467,0.2471453,0.398994279,0.037213859,0.102144973,0.241380251,0.206570975,0.15980803],
+                     c = categorical(["H","F","K","P","P","P","D","M","I","D"]),
+                     w1 = [20,40,35,12,29,25,65,105,30,75],
+                     w2 = [0.04587156,0.091743119,0.080275229,0.027522936,0.066513761,0.05733945,0.149082569,0.240825688,0.068807339,0.172018349])
+    m1 = fit(MixedModel, @formula(a ~ 1 + b + (1|c)), data)
+    m2 = fit(MixedModel, @formula(a ~ 1 + b + (1|c)), data, wts = data.w1)
+
+    @test m1.θ ≈ [0.0]
+    @test m2.θ ≈ [0.295181729258352]  atol = 1.e-4
+
+    @test stderror(m1) ≈  [1.084912, 4.966336] atol = 1.e-4
+    @test stderror(m2) ≈  [0.9640167, 3.6309696] atol = 1.e-4
+    @test vcov(m1) ≈ [1.177035 -4.802598; -4.802598 24.664497] atol = 1.e-4
+    @test vcov(m2) ≈ [0.9293282 -2.557527; -2.5575267 13.183940] atol = 1.e-4
 end


### PR DESCRIPTION
Closes #194.

The fundamental problem was that the weights weren't taken into account when creating A and L. Since the weights never changed, `reweight!` was also never called, which would have updated them accordingly.