### PR TITLE
make (1|x) + (y|x) equivalent to (1|x) + (0+y|x)

### DIFF
--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -60,7 +60,7 @@ function StatsModels.apply_schema(
         !StatsModels.hasintercept(lhs) &&
         !StatsModels.omitsintercept(lhs) &&
         ConstantTerm(1) ∉ schema.already &&
-        InterceptTerm{True}() ∉ schema.already
+        InterceptTerm{true}() ∉ schema.already
     )
         lhs = InterceptTerm{true}() + lhs
     end

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -56,7 +56,12 @@ function StatsModels.apply_schema(
 
     schema = get!(schema.subs, rhs, StatsModels.FullRank(schema.base.schema))
 
-    if !StatsModels.hasintercept(lhs) && !StatsModels.omitsintercept(lhs)
+    if (
+        !StatsModels.hasintercept(lhs) &&
+        !StatsModels.omitsintercept(lhs) &&
+        ConstantTerm(1) ∉ schema.already &&
+        InterceptTerm{True}() ∉ schema.already
+    )
         lhs = InterceptTerm{true}() + lhs
     end
     lhs, rhs = apply_schema.((lhs, rhs), Ref(schema), Mod)

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -378,6 +378,24 @@ end
     # amalgamate should set these to -0.0 to indicate structural zeros
     @test all(ρs_intercept .=== -0.0)
 
+    # also works without explicitly dropped intercept
+    fm_cat2 = fit(MixedModel, @formula(reaction ~ 1+days+(1|subj)+(days|subj)),slpcat)
+    @test fm_cat2 isa LinearMixedModel
+    σρ = fm_cat2.σρs
+    @test σρ isa NamedTuple
+    @test isone(length(σρ))
+    @test first(keys(σρ)) == :subj
+    @test keys(σρ.subj) == (:σ, :ρ)
+    @test length(σρ.subj) == 2
+    @test length(first(σρ.subj)) == 10
+    @test length(σρ.subj.ρ) == 45
+    # test that there's no correlation between the intercept and days columns
+    ρs_intercept = σρ.subj.ρ[1 .+ cumsum(0:8)]
+    @test all(iszero.(ρs_intercept))
+    # amalgamate should set these to -0.0 to indicate structural zeros
+    @test all(ρs_intercept .=== -0.0)
+    
+
     show(io, BlockDescription(first(models(:sleepstudy))))
     @test countlines(seekstart(io)) == 3
     @test "Diagonal" in Set(split(String(take!(io)), r"\s+"))


### PR DESCRIPTION
After #269, a formula like `(1|x) + (y|x)` produces an error because we're
trying to add an extra intercept term to `(y|x)`, producing a non-unique
`(Intercept)` term.  This PR checks whether the schema associated with `|x` has
already seen or generated an intercept term in any earlier term before adding
one.  With this change, `(1|x) + (y|x)` is equivalent to `(1|x) + (0+y|x)`.  I
have a really hard time seeing why someone would want the behavior in those
cases to be different but maybe I just haven't thought about it hard enough

Inspired by @palday's comment in #255.
