### PR TITLE
Use views, clean up ssqdenom

### DIFF
--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -843,8 +843,8 @@ The difference is analagous to the use of n or n-1 in the denominator when
 calculating the variance.
 """
 function ssqdenom(m::LinearMixedModel)::Int
-    dd = m.dims
-    dd.n - m.optsum.REML * dd.p
+    n = m.dims.n
+    m.optsum.REML ? n - m.dims.p : n
 end
 
 """


### PR DESCRIPTION
- For Julia v1.5.0 and later it is an advantage to use views, as in this `rankUpdate` method for sparse `A`
- Slightly cleaner code for `ssqdenom`.  If I am reading the profile timings correctly, `ssqdenom` is a non-negligible part of the time spent in `objective`.