### PR TITLE
Fix grouping name and amalgamate for interaction grouping terms

### DIFF
--- a/.github/workflows/Future.yml
+++ b/.github/workflows/Future.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1.5.0-rc1, nightly]
+        julia-version: [1.5, nightly]
         julia-arch: [x64]
         os: [ubuntu-18.04]
     steps:

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -417,7 +417,7 @@ end
 
 Return the names of the grouping factors for the random-effects terms.
 """
-fnames(m::MixedModel) = ((tr.trm.sym for tr in m.reterms)...,)
+fnames(m::MixedModel) = (fname.(m.reterms)...,)
 
 """
     getθ(m::LinearMixedModel)

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -37,7 +37,7 @@ amalgamate(reterms::Vector{ReMat{T,S}}) where {T,S} = _amalgamate(reterms,T)
 function _amalgamate(reterms::Vector, T::Type)
     factordict = Dict{Symbol, Vector{Int}}()
     for (i, rt) in enumerate(reterms)
-        push!(get!(factordict, rt.trm.sym, Int[]), i)
+        push!(get!(factordict, fname(rt), Int[]), i)
     end
     length(factordict) == length(reterms) && return reterms
     value = ReMat{T}[]


### PR DESCRIPTION
There was a bug in how random effects like `(1 | a&b)` worked with amalgamate
and `fnames` (and hence `VarCorr` and display), because those paths were still
trying to use the `.sym` field on the grouping term.  I've replaced all
instances where `.sym` is used on a grouping term with a call to `fname`
(introduced in #197).

Also adds tests for `fit` with nesting and `&` in random effect grouping to
check the whole pipeline and to test equivalency of `(1 | a/b)` and `(1 | a&b) +
(1 | a)` (using the pastes data).
