### PR TITLE
Fix for one tiny aspect of the rank deficiency issues

### DIFF
--- a/src/linalg/statschol.jl
+++ b/src/linalg/statschol.jl
@@ -10,9 +10,9 @@ function statscholesky(xtx::Symmetric{T}, tol::Real = -1) where {T<:AbstractFloa
     n = size(xtx, 2)
     chpiv = cholesky(xtx, Val(true), tol = T(-1), check = false)
     chunp = cholesky(xtx, check = false)
-    r = chpiv.rank
+    r = (chunp.info == 0) ? n : chpiv.rank
     piv = [1:n;]
-    if chunp.info > 0
+    if r < n
         nleft = n
         while r < nleft
             k = chunp.info

--- a/src/linalg/statschol.jl
+++ b/src/linalg/statschol.jl
@@ -12,7 +12,7 @@ function statscholesky(xtx::Symmetric{T}, tol::Real = -1) where {T<:AbstractFloa
     chunp = cholesky(xtx, check = false)
     r = chpiv.rank
     piv = [1:n;]
-    if r < n
+    if chunp.info > 0
         nleft = n
         while r < nleft
             k = chunp.info


### PR DESCRIPTION
This fixes one tiny facet of the bigger issue lurking in #324.

In particular, OpenBLAS on SkyLakeX can do something weird for some (full rank!) matrices:

- The pivoted Cholesky estimates rank below full.
- The unpivoted Cholesky has `info ==0`, which means that the unpivoted Cholesky succeeded, suggesting numerical full rank.

In this case, the old code generated an invalid permutation consisting of the identity permutation with an extra element `0` appended to the end. The fix here trusts the success of the unpivoted Cholesky more than the rank of the pivoted Cholesky.