### PR TITLE
StatsModels.lrtest support methods

### DIFF
--- a/.github/workflows/Tier1.yml
+++ b/.github/workflows/Tier1.yml
@@ -37,7 +37,7 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - uses: julia-actions/julia-docdeploy@releases/v1
-        if: startsWith(matrix.os, 'Ubuntu')
+        if: ${{ startsWith(matrix.os, 'Ubuntu') && startsWith(matrix.julia-version, '1.5') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -51,7 +51,7 @@ Likeihood ratio test applied to a set of nested models.
 
 Note that nesting of the models is not checked.  It is incumbent on the user 
 to check this. This differs from [`StatsModels.lrtest`](@ref) as nesting in 
-mixed models, especially in the random effects specification may be non obvious.
+mixed models, especially in the random effects specification, may be non obvious.
 
 This functionality may be deprecated in the future in favor of [`StatsModels.lrtest`](@ref).
 """

--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -45,34 +45,22 @@ end
 Base.getindex(lrt::LikelihoodRatioTest, s::Symbol) = getfield(lrt,s)
 
 """
-    likelihoodratiotest(m::LinearMixedModel...)
+    likelihoodratiotest(m::MixedModel...)
 
 Likeihood ratio test applied to a set of nested models.
 
-Note that nesting of the models is not checked.  It is incumbent on the user to check this.
+Note that nesting of the models is not checked.  It is incumbent on the user 
+to check this. This differs from [`StatsModels.lrtest`](@ref) as nesting in 
+mixed models, especially in the random effects specification may be non obvious.
+
+This functionality may be deprecated in the future in favor of [`StatsModels.lrtest`](@ref).
 """
-function likelihoodratiotest(m::LinearMixedModel...)
-    allequal(getproperty.(getproperty.(m,:optsum),:REML)) ||
-        throw(ArgumentError("Models must all be fit with the same objective (i.e. all ML or all REML)"))
-    if any(getproperty.(getproperty.(m,:optsum),:REML))
-        allequal(coefnames.(m))  ||
-                throw(ArgumentError("Likelihood-ratio tests for REML-fitted models are only valid when the fixed-effects specifications are identical"))
-    end
-    _likelihoodratiotest(m...)
-end
-
-function likelihoodratiotest(m::GeneralizedLinearMixedModel...)
-    # TODO: test that all models are fit with same fast/nAGQ option?
-    glms = getproperty.(m,:resp);
-    allequal(Distribution.(glms)) ||
-        throw(ArgumentError("Models must be fit to the same distribution"))
-    allequal(string.(Link.(glms))) ||
-        throw(ArgumentError("Models must have the same link function"))
-
-    _likelihoodratiotest(m...)
-end
-
-function _likelihoodratiotest(m::Vararg{T}) where T <: MixedModel
+function likelihoodratiotest(m::MixedModel...)
+    _iscomparable(m...) || throw(
+            ArgumentError("""Models are not comparable: are the objectives, data
+                             and, where approriate, the link and family the same?
+            """))
+    
     m = collect(m)   # change the tuple to an array
     dofs = dof.(m)
     formulas = String.(Symbol.(getproperty.(m,:formula)))
@@ -161,33 +149,64 @@ function Base.show(io::IO, lrt::LikelihoodRatioTest; digits=2)
     nothing
 end
 
-function _isnested(m::LinearMixedModel...)
+function _iscomparable(m::LinearMixedModel...)
     allequal(getproperty.(getproperty.(m,:optsum),:REML)) ||
         throw(ArgumentError("Models must all be fit with the same objective (i.e. all ML or all REML)"))
+    
     if any(getproperty.(getproperty.(m,:optsum),:REML))
         allequal(coefnames.(m))  ||
                 throw(ArgumentError("Likelihood-ratio tests for REML-fitted models are only valid when the fixed-effects specifications are identical"))
     end
 
+    allequal(nobs.(m)) || 
+        throw(ArgumentError("Models must have the same number of observations"))
+    
     true
 end
 
-function _isnested(m::GeneralizedLinearMixedModel...)
+function _iscomparable(m::GeneralizedLinearMixedModel...)
         # TODO: test that all models are fit with same fast/nAGQ option?
         glms = getproperty.(m,:resp);
         
-        if !allequal(Distribution.(glms))
-            @error "Models must be fit to the same distribution"
-        end
-        
-        if !allequal(string.(Link.(glms)))
-            @error "Models must have the same link function"
-        end
+        iallequal(Distribution.(glms)) ||
+            throw(ArgumentError("Models must be fit to the same distribution"))
+                
+        allequal(string.(Link.(glms))) || 
+            throw(ArgumentError("Models must have the same link function"))
 
+        allequal(nobs.(m)) || 
+            throw(ArgumentError("Models must have the same number of observations"))
+        
         true
 end
 
+"""
+    isnested(m1::MixedModel, m2::MixedModel; atol::Real=0.0)
+Indicate whether model `m1` is nested in model `m2`, i.e. whether
+`m1` can be obtained by constraining some parameters in `m2`.
+Both models must have been fitted on the same data. This check
+is conservative for `MixedModel`s and may reject nested models with different
+parameterizations as being non nested. 
+"""
 function StatsModels.isnested(m1::MixedModel, m2::MixedModel; atol::Real=0.0)
-    _isnested(m1, m2)
+    _iscomparable(m1, m2) || return false
+    
+    # check that the nested fixef are a subset of the outer
+    all(in.(coefnames(m1),  Ref(coefnames(m2)))) || return false
+    
 
+    # check that the same grouping vars occur in the outer model
+    grpng1 = getproperty.(getproperty.(m1.reterms, :trm), :sym)
+    grpng2 = getproperty.(getproperty.(m2.reterms, :trm), :sym)
+
+    all(in.(grpng1, Ref(grpng2))) || return false
+
+    # check that every intercept/slope for a grouping var occurs in the 
+    # same grouping
+    re1 = Dict(re.trm.sym => re.cnames for re in m1.reterms)
+    re2 = Dict(re.trm.sym => re.cnames for re in m2.reterms)
+
+    all(all(in.(val, Ref(re2[key]))) for (key, val) in re1) || return false
+
+    true
 end

--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -168,7 +168,7 @@ function _iscomparable(m::GeneralizedLinearMixedModel...)
         # TODO: test that all models are fit with same fast/nAGQ option?
         glms = getproperty.(m,:resp);
         
-        iallequal(Distribution.(glms)) ||
+        allequal(Distribution.(glms)) ||
             throw(ArgumentError("Models must be fit to the same distribution"))
                 
         allequal(string.(Link.(glms))) || 

--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -189,7 +189,12 @@ is conservative for `MixedModel`s and may reject nested models with different
 parameterizations as being non nested. 
 """
 function StatsModels.isnested(m1::MixedModel, m2::MixedModel; atol::Real=0.0)
-    _iscomparable(m1, m2) || return false
+    try
+        _iscomparable(m1, m2)    
+    catch e
+        @error e.msg
+        false
+    end || return false
     
     # check that the nested fixef are a subset of the outer
     all(in.(coefnames(m1),  Ref(coefnames(m2)))) || return false

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -4,7 +4,8 @@
 Return the equality of all elements of the array
 """
 function allequal(x::Array; comparison=isequal)::Bool
-    all(comparison.(first(x),  x))
+    # the ref is necessary in case the elements of x are themselves arrays
+    all(comparison.(x,  Ref(first(x))))
 end
 
 allequal(x::Vector{Bool})::Bool = !any(x) || all(x)
@@ -12,11 +13,11 @@ allequal(x::Vector{Bool})::Bool = !any(x) || all(x)
 allequal(x::NTuple{N,Bool}) where {N} = !any(x) || all(x)
 
 function allequal(x::Tuple; comparison=isequal)::Bool
-    all(comparison.(first(x),  x))
+    all(comparison.(x,  Ref(first(x))))
 end
 
 function allequal(x...; comparison=isequal)::Bool
-    all(comparison.(first(x),  x))
+    all(comparison.(x,  Ref(first(x))))
 end
 
 """

--- a/test/likelihoodratiotest.jl
+++ b/test/likelihoodratiotest.jl
@@ -29,11 +29,14 @@ include("modelcache.jl")
     m2 = LinearMixedModel(@formula(rt_trunc ~ 1 + (1|item)), kb07)
     @test !isnested(m1, m2)
 
-    # mismatched grouping vars
+    # fixed-effects specification in REML and 
+    # conversion of internal ArgumentError into @error for StatsModels.isnested
     kb07  = dataset(:kb07)
     m1 = fit(MixedModel, @formula(rt_trunc ~ 1 + prec + (1|subj)), kb07, REML=true)
     m2 = fit(MixedModel, @formula(rt_trunc ~ 1 + prec + (1+prec|subj)), kb07, REML=true)
     @test isnested(m1, m2)
+    m2 = fit(MixedModel, @formula(rt_trunc ~ 1 + (1+prec|subj)), kb07, REML=true)
+    @test !isnested(m1, m2)
 
 end
 

--- a/test/likelihoodratiotest.jl
+++ b/test/likelihoodratiotest.jl
@@ -29,6 +29,12 @@ include("modelcache.jl")
     m2 = LinearMixedModel(@formula(rt_trunc ~ 1 + (1|item)), kb07)
     @test !isnested(m1, m2)
 
+    # mismatched grouping vars
+    kb07  = dataset(:kb07)
+    m1 = fit(MixedModel, @formula(rt_trunc ~ 1 + prec + (1|subj)), kb07, REML=true)
+    m2 = fit(MixedModel, @formula(rt_trunc ~ 1 + prec + (1+prec|subj)), kb07, REML=true)
+    @test isnested(m1, m2)
+
 end
 
 @testset "likelihoodratio test" begin

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -27,6 +27,9 @@ end
 	@test allequal([false, false, false])
 	@test allequal(ones(3))
 	@test allequal(1, 1, 1)
+
+	# equality of arrays with broadcasting
+	@test allequal(["(Intercept)", "days"], ["(Intercept)", "days"])
 end
 
 @testset "threaded_replicate" begin


### PR DESCRIPTION
For now, we're keeping `likelihoodratiotest` in. Two main reasons for that:

1. We print the formulae (but this can change)
2. We use don't check nesting (just basic compatibility in terms of family, links, objective, etc.). This means we get fewer false positives in cases like alternative specifications of compound symmetric random effects.

Closes #320.