### PR TITLE
keep user-specified formula for display purposes

### DIFF
--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -98,7 +98,7 @@ function LinearMixedModel(
     optsum = OptSummary(θ, lbd, :LN_BOBYQA, ftol_rel = T(1.0e-12), ftol_abs = T(1.0e-8))
     fill!(optsum.xtol_abs, 1.0e-10)
     LinearMixedModel(
-        form,
+        f,
         allterms,
         sqrtwts,
         mkparmap(reterms),

--- a/test/likelihoodratiotest.jl
+++ b/test/likelihoodratiotest.jl
@@ -43,8 +43,6 @@ end
 @testset "likelihoodratio test" begin
     slp = dataset(:sleepstudy);
     
-
-
     fm0 = fit(MixedModel,@formula(reaction ~ 1 + (1+days|subj)),slp);
     fm1 = fit(MixedModel,@formula(reaction ~ 1 + days + (1+days|subj)),slp);
 


### PR DESCRIPTION
After using `apply_schema`, the user-specified formula is expanded out such that `a * b` is now represented as `a + b + a&b`. This is undesirable for display purposes, which is the only reason we keep the formula object around after model construction. If we use the original formula specified by the user, then everything stays nice and pretty.

Cons:
1. The fully expanded formula isn't immediately available. But we don't need this and if the user wants to see which terms there are in the model, then they can get this via `coefnames`. 
2. Information about contrast coding is no longer explicitly stored in the model. (In the expanded formula, the contrasts are part of the schema and so are stored with the terms.)  It's implicitly there in the fixed-efffects model matrix. I'm not sure how useful this information is after the fact. If this is really an issue, we could just store the `contrasts` dictionary as part of the `LinearMixedModel` struct.