### PR TITLE
Documentation for fulldummy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
-author = ["Phillip Alday <phillip.alday@mpi.nl>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
+author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
 version = "3.0.0-DEV"
 
 [deps]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -11,8 +11,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 BenchmarkTools = "0.5"
-DataFrames = "0.20"
-Documenter = "0.24"
-FreqTables = "0.3"
+DataFrames = "0.21"
+Documenter = "0.25"
+FreqTables = "0.4"
 Gadfly = "1"
-StatsBase = "0.32"
+StatsBase = "0.33"

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -121,6 +121,14 @@ fulldummy(t::AbstractTerm) =
     throw(ArgumentError("can't promote $t (of type $(typeof(t))) to full dummy " *
                         "coding (only CategoricalTerms)"))
 
+"""
+    fulldummy(term::CategoricalTerm)
+
+Assign "contrasts" that include all indicator columns (dummy variables) and an intercept column.
+
+This will result in an under-determined set of contrasts, which is not a problem in the random
+effects because of the regularization, or "shrinkage", of the conditional modes.
+"""
 function fulldummy(t::CategoricalTerm)
     new_contrasts = StatsModels.ContrastsMatrix(
         StatsModels.FullDummyCoding(),

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -128,6 +128,11 @@ Assign "contrasts" that include all indicator columns (dummy variables) and an i
 
 This will result in an under-determined set of contrasts, which is not a problem in the random
 effects because of the regularization, or "shrinkage", of the conditional modes.
+
+The interaction of `fulldummy` with complex random effects is subtle and complex with numerous 
+potential edge cases. As we discover these edge cases, we will document and determine their 
+behavior. Until such time, please check the model summary to verify that the expansion is 
+working as you expected. If it is not, please report a use case on GitHub.
 """
 function fulldummy(t::CategoricalTerm)
     new_contrasts = StatsModels.ContrastsMatrix(


### PR DESCRIPTION
- closes #255 
- add a docstring for `fulldummy` and an example in the `constructors.md` source file for the online documentation