### PR TITLE
PCA row labels

### DIFF
--- a/src/remat.jl
+++ b/src/remat.jl
@@ -386,10 +386,12 @@ end
 
 function PCA(A::ReMat{T,1}; corr::Bool=true) where {T}
     val = ones(T, 1, 1)
-    PCA(corr ? val : abs(only(A.λ)) * val, corr=corr)
+    # TODO: use DataAPI
+    PCA(corr ? val : abs(only(A.λ)) * val, A.cnames; corr=corr)
 end
 
-PCA(A::ReMat{T,S}; corr::Bool=true) where {T,S} = PCA(A.λ, corr=corr)
+# TODO: use DataAPI
+PCA(A::ReMat{T,S}; corr::Bool=true) where {T,S} = PCA(A.λ, A.cnames; corr=corr)
 
 function reweight!(A::ReMat, sqrtwts::Vector)
     if length(sqrtwts) > 0

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -246,8 +246,9 @@ function Base.show(io::IO, pca::PCA;
         if pca.rnames !== missing 
             n = length(pca.rnames)
             cv = string.(printmat)
+            dotpad = lpad(".", div(maximum(length, cv),2))
             for i = 1:n, j = (i+1):n
-                cv[i, j] = ""
+                cv[i, j] = dotpad
             end
             neg = startswith.(cv, "-")
             if any(neg)

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -6,6 +6,9 @@ using Test
 
 using MixedModels: allequal, average, densify, dataset
 
+const io = IOBuffer()
+include("modelcache.jl")
+
 @testset "average" begin
 	@test average(1.1, 1.2) == 1.15
 end
@@ -51,4 +54,17 @@ end
 	@test size(MixedModels.dataset(:dyestuff)) == (30, 2)
 	@test size(MixedModels.dataset("dyestuff")) == (30, 2)
 	@test_throws ArgumentError MixedModels.dataset(:foo)
+end
+
+@testset "PCA" begin
+	pca = models(:kb07)[3].PCA.item
+	
+	show(io, pca, covcor=true, loadings=false)
+	str = String(take!(io))
+	@test !isempty(findall("load: yes        0.18   0.16  -0.14   1.0", str))
+	
+	show(io, pca, covcor=false, loadings=true)
+	str = String(take!(io))
+	@test !isempty(findall("PC1    PC2    PC3    PC4", str))
+	@test !isempty(findall("load: yes       -0.19  -0.63  -0.75  -0.02", str))
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -61,10 +61,10 @@ end
 	
 	show(io, pca, covcor=true, loadings=false)
 	str = String(take!(io))
-	@test !isempty(findall("load: yes        0.18   0.16  -0.14   1.0", str))
+	@test !isempty(findall("load: yes", str))
 	
 	show(io, pca, covcor=false, loadings=true)
 	str = String(take!(io))
-	@test !isempty(findall("PC1    PC2    PC3    PC4", str))
-	@test !isempty(findall("load: yes       -0.19  -0.63  -0.75  -0.02", str))
+	@test !isempty(findall("PC1", str))
+	@test !isempty(findall("load: yes", str))
 end


### PR DESCRIPTION
Closes #340.

Sample of output:
```julia
julia> m1 = fit(MixedModel, @formula(score ~ 1 + Machine + (1 + Machine | Worker)), MixedModels.dataset(:machines))
Linear mixed model fit by maximum likelihood
 score ~ 1 + Machine + (1 + Machine | Worker)
   logLik   -2 logLik     AIC        BIC    
  -108.2089   216.4178   236.4178   256.3077

Variance components:
            Column    Variance Std.Dev.   Corr.
Worker   (Intercept)  13.813236 3.716616
         Machine: B   28.684049 5.355749 +0.49
         Machine: C   11.240468 3.352681 -0.36 +0.30
Residual               0.924687 0.961606
 Number of obs: 54; levels of grouping factors: 6

  Fixed-effects parameters:
──────────────────────────────────────────────────
                Coef.  Std. Error      z  Pr(>|z|)
──────────────────────────────────────────────────
(Intercept)  52.3556      1.53414  34.13    <1e-99
Machine: B    7.96667     2.20985   3.61    0.0003
Machine: C   13.9167      1.40576   9.90    <1e-22
──────────────────────────────────────────────────

julia> m1.PCA.Worker

Principal components based on correlation matrix
 (Intercept)   1.0     .     .
 Machine: B    0.49   1.0    .
 Machine: C   -0.36   0.3   1.0

Normalized cumulative variances:
[0.4988, 0.9235, 1.0]

Component loadings
                PC1    PC2    PC3
 (Intercept)  -0.75   0.23   0.62
 Machine: B   -0.64  -0.49  -0.59
 Machine: C    0.17  -0.84   0.52
```
