### PR TITLE
note on threading in bootstrap

### DIFF
--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -45,6 +45,12 @@ The default random number generator is `Random.GLOBAL_RNG`.
 
 `β`, `σ`, and `θ` are the values of `m`'s parameters for simulating the responses.
 `use_threads` determines whether or not to use thread-based parallelism.
+
+Note that `use_threads=true` may not offer a performance boost and may even 
+decrease peformance if multithreaded linear algebra (BLAS) routines are available.
+In this case, threads at the level of the linear algebra may already occupy all 
+processors/processor cores. There are plans to provide better support in coordinating
+Julia- and BLAS-level threads in the future. 
 """
 function parametricbootstrap(
     rng::AbstractRNG,


### PR DESCRIPTION
For now, I would like to leave the threading option in the API for a few reasons:

1. There are some machines with dozens (or even > 100 cores) where there might actually be some boost from threading at both the BLAS and simultaneous fits levels. These aren't so rare in university clusters -- I have seen a few in neuroscience.
2. I suspect it might be possible to eek out a bit more of a performance boost with finer grained locking, but that's not for today.3
3. If someone is using an alternative BLAS that isn't multi-threaded but still has multiple cores (maybe this is the case on ARM?), then they can still get a boost from multithreading.