### PR TITLE
fix propogation of defaults in non-column table contructor

### DIFF
--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -317,10 +317,9 @@ GeneralizedLinearMixedModel(
     Tables.columntable(tbl),
     d,
     l;
-    wts = [],
-    offset = [],
-    contrasts = Dict{Symbol,Any}(),
-)
+    wts = wts,
+    offset = offset,
+    contrasts = contrasts)
 
 GeneralizedLinearMixedModel(
     f::FormulaTerm,


### PR DESCRIPTION
This is a nasty, subtle bug about where you set the defaults.