### PR TITLE
Fixes for running tests on 1.6.0-dev

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,5 +1,5 @@
-# when generating a new artifact, add the new feather file to the datasets folder at
-# https://osf.io/a94tr/, then download that folder to generate the tarball
+# when generating a new artifact, add the new feather file to the datasets folder in Arrow format at
+# https://osf.io/djaqb/, then download that folder to generate the tarball
 # (so that we don't forget datasets)
 
 [TestData]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -242,7 +242,7 @@ function Base.show(io::IO, pca::PCA;
                 pca.corr ? "correlation" : "(relative) covariance",
                 " matrix")
         # only display the lower triangle of symmetric matrix
-        printmat = round.(LowerTriangular(pca.covcor), digits=ndigitsmat)
+        printmat = round.(pca.covcor.data, digits=ndigitsmat)
         if pca.rnames !== missing 
             n = length(pca.rnames)
             cv = string.(printmat)

--- a/test/modelcache.jl
+++ b/test/modelcache.jl
@@ -32,11 +32,14 @@ const global fms = Dict(
     ],
 )
 
-const global fittedmodels = Dict{Symbol,Vector{LinearMixedModel}}();
+# for some reason it seems necessary to prime the pump in julia-1.6.0-DEV
+const global fittedmodels = Dict{Symbol,Vector{LinearMixedModel}}(
+    :dyestuff => [fit(MixedModel, only(fms[:dyestuff]), dataset(:dyestuff))]
+);
 end
 
 function models(nm::Symbol)
     get!(fittedmodels, nm) do
-        fit.(MixedModel, fms[nm], Ref(dataset(nm)))
+        [fit(MixedModel, f, dataset(nm)) for f in fms[nm]]
     end
 end

--- a/test/modelcache.jl
+++ b/test/modelcache.jl
@@ -1,14 +1,8 @@
 using MixedModels
 using MixedModels: dataset
 
-try 
-    # this a dummy test to see if these things are already defined
-    fms
-catch e
 
-isa(e, UndefVarError) || rethrow(e)
-
-const global fms = Dict(
+@isdefined(fms) || const global fms = Dict(
     :dyestuff => [@formula(yield ~ 1 + (1|batch))],
     :dyestuff2 => [@formula(yield ~ 1 + (1|batch))],
     :d3 => [@formula(y ~ 1 + u + (1+u|g) + (1+u|h) + (1+u|i))],
@@ -35,10 +29,9 @@ const global fms = Dict(
 )
 
 # for some reason it seems necessary to prime the pump in julia-1.6.0-DEV
-const global fittedmodels = Dict{Symbol,Vector{LinearMixedModel}}(
+@isdefined(fittedmodels) || const global fittedmodels = Dict{Symbol,Vector{LinearMixedModel}}(
     :dyestuff => [fit(MixedModel, only(fms[:dyestuff]), dataset(:dyestuff))]
 );
-end
 
 function models(nm::Symbol)
     get!(fittedmodels, nm) do


### PR DESCRIPTION
- Change in `show` method for `PCA` to avoid `string.` applied to a `LowerTriangular` matrix
- "Prime the pump" by starting the `fittedmodels` Dict with a value.  1.6.0-DEV seems to hang on compilation for any call to `models` without that.
- Update a comment in `Artifacts.toml`
- Fixes #387, fixes #402