### PR TITLE
simulate! and thus parametricbootstrap for GLMM

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@ MixedModels v3.1 Release Notes
 ========================
 
 * `simulate!` and thus `parametricbootstrap` methods for `GeneralizedLinearMixedModel` [#418].
+* Documented inconsistent behavior in `sdest` and `varest` `GeneralizedLinearMixedModel` [#418].
 
 MixedModels v3.0 Release Notes
 ========================

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+MixedModels v3.1 Release Notes
+========================
+
+* `simulate!` and thus `parametricbootstrap` methods for `GeneralizedLinearMixedModel` [#418].
+
 MixedModels v3.0 Release Notes
 ========================
 
@@ -43,12 +48,12 @@ Principal components
 ----------------------------------
 
 * An `AbstractReMat` type has now been introduced to support [#380] work on constrained
-  random-effects structures and random-effects structures appropriate for applications 
-  in GLM-based decovolution as used in fMRI and EEG (see e.g. [unfold.jl](https://github.com/unfoldtoolbox/unfold.jl).) 
+  random-effects structures and random-effects structures appropriate for applications
+  in GLM-based decovolution as used in fMRI and EEG (see e.g. [unfold.jl](https://github.com/unfoldtoolbox/unfold.jl).)
 * Similarly, a constructor for `FeMat{::SparseMatrixCSC,S}` has been introduced [#309].
-  Currently, this constructor assumes a full-rank matrix, but the work on rank 
+  Currently, this constructor assumes a full-rank matrix, but the work on rank
   deficiency may be extended to this constructor as well.
-* Analogous to `AbstractReMat`, an `AbstractReTerm <: AbstractTerm` type  has been introduced [#395]. 
+* Analogous to `AbstractReMat`, an `AbstractReTerm <: AbstractTerm` type  has been introduced [#395].
   Terms created with `zerocorr` are of type `ZeroCorr <: AbstractReTerm`.
 
 Availability of test data sets
@@ -85,3 +90,4 @@ Package dependencies
 [#384]: https://github.com/JuliaStats/MixedModels.jl/issues/384
 [#390]: https://github.com/JuliaStats/MixedModels.jl/issues/390
 [#395]: https://github.com/JuliaStats/MixedModels.jl/issues/395
+[#418]: https://github.com/JuliaStats/MixedModels.jl/issues/418

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "3.0.0"
+version = "3.1.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -1,7 +1,7 @@
-# Parametric bootstrap for linear mixed-effects models
+# Parametric bootstrap for mixed-effects models
 
 Julia is well-suited to implementing bootstrapping and other simulation-based methods for statistical models.
-The `parametricbootstrap` function in the [MixedModels package](https://github.com/JuliaStats/MixedModels.jl) provides an efficient parametric bootstrap for linear mixed-effects models.
+The `parametricbootstrap` function in the [MixedModels package](https://github.com/JuliaStats/MixedModels.jl) provides an efficient parametric bootstrap for mixed-effects models.
 
 ```@docs
 parametricbootstrap
@@ -98,7 +98,7 @@ For example, if we bootstrap a model fit to the `sleepstudy` data
 sleepstudy = MixedModels.dataset(:sleepstudy)
 m2 = fit(
     MixedModel,
-    @formula(reaction ~ 1+days+(1+days|subj)), 
+    @formula(reaction ~ 1+days+(1+days|subj)),
     sleepstudy,
 )
 ```
@@ -131,7 +131,7 @@ sum(ρs .≈ -1)
 
 Furthermore there are even a few cases where the estimate of the standard deviation of the random effect for the intercept is zero.
 ```@example Main
-σs = @where(df2, :type .== "σ", :group .== "subj", :names .== "(Intercept)").value 
+σs = @where(df2, :type .== "σ", :group .== "subj", :names .== "(Intercept)").value
 sum(σs .≈ 0)
 ```
 
@@ -139,7 +139,7 @@ There is a general condition to check for singularity of an estimated covariance
 The parameter optimized in the estimation is `θ`, the relative covariance parameter.
 Some of the elements of this parameter vector must be non-negative and, when one of these components is approximately zero, one of the covariance matrices will be singular.
 
-The `issingular` method for a `LinearMixedModel` object that tests if a parameter vector `θ` corresponds to a boundary or singular fit.
+The `issingular` method for a `MixedModel` object that tests if a parameter vector `θ` corresponds to a boundary or singular fit.
 
 This operation is encapsulated in a method for the `issingular` function.
 ```@example Main

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -44,18 +44,20 @@ The default random number generator is `Random.GLOBAL_RNG`.
 # Named Arguments
 
 `β`, `σ`, and `θ` are the values of `m`'s parameters for simulating the responses.
+`σ` is only valid for `LinearMixedModel` and `GeneralizedLinearMixedModel` when
+the family that has a dispersion parameter.
 `use_threads` determines whether or not to use thread-based parallelism.
 
-Note that `use_threads=true` may not offer a performance boost and may even 
+Note that `use_threads=true` may not offer a performance boost and may even
 decrease peformance if multithreaded linear algebra (BLAS) routines are available.
-In this case, threads at the level of the linear algebra may already occupy all 
+In this case, threads at the level of the linear algebra may already occupy all
 processors/processor cores. There are plans to provide better support in coordinating
-Julia- and BLAS-level threads in the future. 
+Julia- and BLAS-level threads in the future.
 """
 function parametricbootstrap(
     rng::AbstractRNG,
     n::Integer,
-    morig::LinearMixedModel{T};
+    morig::MixedModel{T};
     β::AbstractVector=coef(morig),
     σ=morig.σ,
     θ::AbstractVector=morig.θ,
@@ -108,7 +110,7 @@ end
 
 function parametricbootstrap(
     nsamp::Integer,
-    m::LinearMixedModel;
+    m::MixedModel;
     β = m.β,
     σ = m.σ,
     θ = m.θ,
@@ -129,7 +131,7 @@ function allpars(bsamp::MixedModelBootstrap{T}) where {T}
     nresrow = length(bstr) * npars
     cols = (
         sizehint!(Int[], nresrow),
-        sizehint!(String[], nresrow), 
+        sizehint!(String[], nresrow),
         sizehint!(Union{Missing,String}[], nresrow),
         sizehint!(Union{Missing,String}[], nresrow),
         sizehint!(T[], nresrow),

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -141,7 +141,7 @@ function allpars(bsamp::MixedModelBootstrap{T}) where {T}
     )
     nrmdr = Vector{T}[]  # normalized rows of λ
     for (i, r) in enumerate(bstr)
-        σ = r.σ === missing ? 1 : r.σ
+        σ = coalesce(r.σ, one(T))
         for (nm, v) in pairs(r.β)
             push!.(cols, (i, "β", missing, String(nm), v))
         end
@@ -304,7 +304,7 @@ function tidyσs(bsamp::MixedModelBootstrap{T}) where {T}
     )
     for (iter, r) in enumerate(bstr)
         setθ!(bsamp, iter)    # install r.θ in λ
-        σ = r.σ === missing ? 1 : r.σ
+        σ = coalesce(r.σ, one(T))
         for (grp, ll) in zip(keys(fcnames), λ)
             for (cn, col) in zip(getproperty(fcnames, grp), eachrow(ll))
                 push!(result, NamedTuple{colnms}((iter, grp, Symbol(cn), σ * norm(col))))

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -188,7 +188,16 @@ function Base.getproperty(bsamp::MixedModelBootstrap, s::Symbol)
     end
 end
 
-issingular(bsamp::MixedModelBootstrap) = map(θ -> any(θ .≈ bsamp.lowerbd), bsamp.θ)
+"""
+    issingular(bsamp::MixedModelBootstrap)
+
+Test each bootstrap sample for singularity of the corresponding fit.
+
+Equality comparisons are used b/c small non-negative θ values are replaced by 0 in `fit!`.
+
+See also [`issingular(::MixedModel)`](@ref).
+"""
+issingular(bsamp::MixedModelBootstrap) = map(θ -> any(θ .== bsamp.lowerbd), bsamp.θ)
 
 function Base.propertynames(bsamp::MixedModelBootstrap)
     [:allpars, :objective, :σ, :β, :se, :coefpvalues, :θ, :σs, :λ, :inds, :lowerbd, :bstr, :fcnames]

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -32,9 +32,9 @@ struct MixedModelBootstrap{T<:AbstractFloat}
 end
 
 """
-    parametricbootstrap(rng::AbstractRNG, nsamp::Integer, m::LinearMixedModel;
+    parametricbootstrap(rng::AbstractRNG, nsamp::Integer, m::MixedModel;
         β = coef(m), σ = m.σ, θ = m.θ, use_threads=false)
-    parametricbootstrap(nsamp::Integer, m::LinearMixedModel;
+    parametricbootstrap(nsamp::Integer, m::MixedModel;
         β = coef(m), σ = m.σ, θ = m.θ, use_threads=false)
 
 Perform `nsamp` parametric bootstrap replication fits of `m`, returning a `MixedModelBootstrap`.

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -658,10 +658,19 @@ function Base.show(io::IO, m::GeneralizedLinearMixedModel)
 end
 
 function stderror!(v::AbstractVector{T}, m::GeneralizedLinearMixedModel{T}) where {T}
-    # this doesn't actually save an allocation, but it provides this method
-    # which is the variant used by the bootstrap
-    copyto!(fill!(v, -zero(T)), stderror(m))
-    invpermute!(v, first(m.feterms).piv)
+    # initialize to appropriate NaN for rank-deficient case
+    fill!(v, zero(T) / zero(T))
+
+    # the inverse permutation is done here.
+    # if this is changed to access the permuted
+    # model matrix directly, then don't forget to add
+    # in the inverse permutation
+    vcovmat = vcov(m)
+
+    for idx in 1:size(vcovmat,1)
+        v[idx] = sqrt(vcovmat[idx,idx])
+    end
+
     v
 end
 

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -625,7 +625,18 @@ function Base.setproperty!(m::GeneralizedLinearMixedModel, s::Symbol, y)
     end
 end
 
-sdest(m::GeneralizedLinearMixedModel{T}) where {T} = convert(T, NaN)
+"""
+    sdest(m::GeneralizedLinearMixedModel)
+
+Return the estimate of the dispersion, i.e. the standard deviation of the per-observation noise.
+
+For models with a dispersion parameter ϕ, this is simply ϕ. For models without a
+dispersion parameter, this value is `missing`. This differs from `disperion`,
+which returns `1` for models without a dispersion parameter.
+
+For Gaussian models, this parameter is often called σ.
+"""
+sdest(m::GeneralizedLinearMixedModel{T}) where {T} =  dispersion_parameter(m) ? dispersion(m, true) : missing
 
 function Base.show(io::IO, m::GeneralizedLinearMixedModel)
     if m.optsum.feval < 0
@@ -692,9 +703,20 @@ function updateη!(m::GeneralizedLinearMixedModel)
     m
 end
 
-varest(m::GeneralizedLinearMixedModel{T}) where {T} = one(T)
+"""
+    varest(m::GeneralizedLinearMixedModel)
 
-            # delegate GLMM method to LMM field
+Returns the estimate of ϕ², the variance of the conditional distribution of Y given B.
+
+For models with a dispersion parameter ϕ, this is simply ϕ². For models without a
+dispersion parameter, this value is `missing`. This differs from `disperion`,
+which returns `1` for models without a dispersion parameter.
+
+For Gaussian models, this parameter is often called σ².
+"""
+varest(m::GeneralizedLinearMixedModel{T}) where {T} = dispersion_parameter(m) ? dispersion(m, true) : missing
+
+# delegate GLMM method to LMM field
 for f in (
     :feL,
     :fetrm,

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -377,7 +377,7 @@ end
 StatsBase.fitted(m::LinearMixedModel{T}) where {T} = fitted!(Vector{T}(undef, nobs(m)), m)
 
 """
-    fixef!(v::Vector{T}, m::LinearMixedModel{T})
+    fixef!(v::Vector{T}, m::MixedModel{T})
 
 Overwrite `v` with the pivoted fixed-effects coefficients of model `m`
 

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -495,15 +495,6 @@ function Base.getproperty(m::LinearMixedModel{T}, s::Symbol) where {T}
     end
 end
 
-"""
-    issingular(m::LinearMixedModel, θ=m.θ)
-
-Test whether the model `m` is singular if the parameter vector is `θ`.
-
-Equality comparisons are used b/c small non-negative θ values are replaced by 0 in `fit!`.
-"""
-issingular(m::LinearMixedModel, θ=m.θ) = any(lowerbd(m) .== θ)
-
 function StatsBase.leverage(m::LinearMixedModel{T}) where {T}
     # This can be done more efficiently but reusing existing tools is easier.
     # The i'th leverage value is obtained by replacing the response with the i'th

--- a/src/mixedmodel.jl
+++ b/src/mixedmodel.jl
@@ -6,6 +6,15 @@ Return a vector of condition numbers of the λ matrices for the random-effects t
 """
 LinearAlgebra.cond(m::MixedModel) = cond.(m.λ)
 
+"""
+    issingular(m::MixedModel, θ=m.θ)
+
+Test whether the model `m` is singular if the parameter vector is `θ`.
+
+Equality comparisons are used b/c small non-negative θ values are replaced by 0 in `fit!`.
+"""
+issingular(m::MixedModel, θ=m.θ) = any(lowerbd(m) .== θ)
+
 function retbl(mat, trm)
     merge(
         NamedTuple{(fname(trm),)}((trm.levels,)),

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -33,7 +33,8 @@ function simulate!(
         unscaledre!(rng, y, trm)
     end
                     # scale by σ and add fixed-effects contribution
-    BLAS.gemv!('N', one(T), m.X, β, σ, y)
+    mul!(y, m.X, β, one(T), σ)
+
     m
 end
 
@@ -93,7 +94,7 @@ function simulate!(
     # add fixed-effects contribution
     # note that unit scaling may not be correct for
     # families with a dispersion parameter
-    BLAS.gemv!('N', one(T), lm.X, β, one(T), η)
+    mul!(η, lm.X, β, one(T), one(T))
 
     # from η to μ
     GLM.updateμ!(m.resp, η)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -80,12 +80,18 @@ function simulate!(
     y = m.resp.y
 
     # assemble the linear predictor
-    @inbounds for trm in m.reterms             # add the unscaled random effects
+
+    # add the unscaled random effects
+    # note that unit scaling may not be correct for
+    # families with a dispersion parameter
+    @inbounds for trm in m.reterms
         unscaledre!(rng, η, trm)
     end
 
-    # scale by lm.σ and add fixed-effects contribution
-    BLAS.gemv!('N', one(T), lm.X, β, lm.σ, η)
+    # add fixed-effects contribution
+    # note that unit scaling may not be correct for
+    # families with a dispersion parameter
+    BLAS.gemv!('N', one(T), lm.X, β, one(T), η)
 
     # from η to μ
     GLM.updateμ!(m.resp, η)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -129,7 +129,7 @@ function _rand(rng::AbstractRNG, d::Distribution, location, scale=NaN, n=1)
     end
 
     if d isa Binomial
-        dist = Binomial(n, location)
+        dist = Binomial(Int(n), location)
     else
         dist = typeof(d)(location)
     end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -56,7 +56,6 @@ function simulate!(
     θ = convert(Vector{T},θ)
 
     d = m.resp.d
-    l = GLM.Link(m.resp)
 
     if length(β) ≠ length(coef(m))
         padding = length(coef(m)) - length(β)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -48,11 +48,13 @@ function simulate!(
         length(β) == length(coef(m)) ||
             throw(ArgumentError("You must specify all (non-singular) βs"))
 
-    dispersion_parameter(m) || isnan(σ) ||
+    dispersion_parameter(m) || ismissing(σ) ||
         throw(ArgumentError("You must not specify a dispersion parameter for model families without a dispersion parameter"))
 
     β = convert(Vector{T},β)
-    σ = T(σ)
+    if σ !== missing
+        σ = T(σ)
+    end
     θ = convert(Vector{T},θ)
 
     d = m.resp.d
@@ -106,7 +108,7 @@ function simulate!(
 end
 
 """
-    _rand(rng::AbstractRNG, d::Distribution, location, scale=NaN, n=1)
+    _rand(rng::AbstractRNG, d::Distribution, location, scale=missing, n=1)
 
 A convenience function taking a draw from a distrbution.
 
@@ -121,7 +123,7 @@ Note that `n` is the `n` parameter for the Binomial distribution,
 random draw (an integer in [0, n]) into a probability (a float in [0,1]).
 """
 function _rand(rng::AbstractRNG, d::Distribution, location, scale=NaN, n=1)
-    if !isnan(scale)
+    if !ismissing(scale)
         throw(ArgumentError("Families with a dispersion parameter not yet supported"))
     end
 

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -105,8 +105,10 @@ end
         gm0 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli(), fast=true)
         bs = parametricbootstrap(StableRNG(42), 100, gm0)
         bsci = combine(groupby(DataFrame(bs.β), :coefname),
-                       :β => first ∘ shortestcovint => :lower,
-                       :β => last ∘ shortestcovint => :upper)
+                       :β => shortestcovint => :ci)
+        bsci.lower = first.(bsci.ci)
+        bsci.upper = last.(bsci.ci)
+        select!(bsci, Not(:ci))
         ciwidth = 2 .* stderror(gm0)
         waldci = DataFrame(coef=fixefnames(gm0),
                            lower=fixef(gm0) .- ciwidth,

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -14,19 +14,25 @@ include("modelcache.jl")
     @testset "LMM" begin
         ds = dataset(:dyestuff)
         fm = only(models(:dyestuff))
+        # # just in case the fit was modified in a previous test
+        # refit!(fm, vec(float.(ds.yield)))
         resp₀ = copy(response(fm))
         # type conversion of ints to floats
         simulate!(StableRNG(1234321), fm, β=[1], σ=1)
         refit!(fm,resp₀)
         refit!(simulate!(StableRNG(1234321), fm))
-        @test deviance(fm) ≈ 334.0334 atol=0.001
+        @test deviance(fm) ≈ 322.6582 atol=0.001
         refit!(fm, float(ds.yield))
         # Global/implicit RNG method
         Random.seed!(1234321)
         refit!(simulate!(fm))
-        @test deviance(fm) ≈ 339.0218639362958 atol=0.001
+        # just make sure this worked, don't check fit
+        # (because the RNG can change between Julia versions)
+        @test response(fm) ≠ resp₀
         simulate!(fm, θ = fm.θ)
         @test_throws DimensionMismatch refit!(fm, zeros(29))
+        # restore the original state
+        refit!(fm, vec(float.(ds.yield)))
     end
 
     @testset "Poisson" begin

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -118,6 +118,12 @@ end
         @test all(isapprox.(bsci.lower, waldci.lower; atol=0.5))
         @test all(isapprox.(bsci.upper, waldci.upper; atol=0.5))
 
+        σbar = mean(MixedModels.tidyσs(bs)) do x; x.σ end
+        @test σbar ≈ 0.56 atol=0.1
+        apar = filter!(row -> row.type == "σ", DataFrame(MixedModels.allpars(bs)))
+        @test !("Residual" in apar.names)
+        @test mean(apar.value) ≈ σbar
+
         # can't specify dispersion for families without that parameter
         @test_throws ArgumentError parametricbootstrap(StableRNG(42), 100, gm0; σ=2)
         @test sum(issingular(bs)) == 0

--- a/test/modelcache.jl
+++ b/test/modelcache.jl
@@ -1,6 +1,12 @@
 using MixedModels
 using MixedModels: dataset
 
+@isdefined(gfms) || const global gfms = Dict(
+    :cbpp => [@formula((incid/hsz) ~ 1 + period + (1|herd))],
+    :contra => [@formula(use ~ 1+age+abs2(age)+urban+livch+(1|urban&dist))],
+    :grouseticks => [@formula(ticks ~ 1+year+ch+ (1|index) + (1|brood) + (1|location))],
+    :verbagg => [@formula(r2 ~ 1+anger+gender+btype+situ+(1|subj)+(1|item))],
+)
 
 @isdefined(fms) || const global fms = Dict(
     :dyestuff => [@formula(yield ~ 1 + (1|batch))],

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -25,6 +25,12 @@ include("modelcache.jl")
     @test isone(length(retbl))
     @test isa(retbl, NamedTuple)
     @test Tables.istable(only(retbl))
+    @test !dispersion_parameter(gm0)
+    @test dispersion(gm0, false) == 1
+    @test dispersion(gm0, true) == 1
+    @test sdest(gm0) === missing
+    @test varest(gm0) === missing
+    @test gm0.σ === missing
 
     gm1 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli());
     @test isapprox(gm1.θ, [0.573054], atol=0.005)
@@ -40,7 +46,6 @@ include("modelcache.jl")
     @test isapprox(deviance(gm1), 2360.8760, atol=0.001)
     @test gm1.β == gm1.beta
     @test gm1.θ == gm1.theta
-    @test isnan(gm1.σ)
     @test length(gm1.y) == size(gm1.X, 1)
     @test :θ in propertynames(gm0)
 
@@ -66,8 +71,12 @@ end
     @test logdet(gm2) ≈ 16.90105378801136 atol=0.0001
     @test isapprox(sum(gm2.resp.devresid), 73.47174762237978, atol=0.001)
     @test isapprox(loglikelihood(gm2), -92.02628186840045, atol=0.001)
-    @test isnan(sdest(gm2))
-    @test varest(gm2) == 1
+    @test !dispersion_parameter(gm2)
+    @test dispersion(gm2, false) == 1
+    @test dispersion(gm2, true) == 1
+    @test sdest(gm2) === missing
+    @test varest(gm2) === missing
+    @test gm2.σ === missing
 
     @testset "GLMM refit" begin
         gm2r = deepcopy(gm2)
@@ -101,6 +110,12 @@ end
     # these two values are not well defined at the optimum
     #@test isapprox(sum(x -> sum(abs2, x), gm4.u), 196.8695297987013, atol=0.1)
     #@test isapprox(sum(gm4.resp.devresid), 220.92685781326136, atol=0.1)
+    @test !dispersion_parameter(gm4)
+    @test dispersion(gm4, false) == 1
+    @test dispersion(gm4, true) == 1
+    @test sdest(gm4) === missing
+    @test varest(gm4) === missing
+    @test gm4.σ === missing
 end
 
 @testset "goldstein" begin # from a 2020-04-22 msg by Ben Goldstein to R-SIG-Mixed-Models
@@ -142,5 +157,12 @@ end
     @test_logs (:warn, r"dispersion parameter") GeneralizedLinearMixedModel(form, dat, Gamma())
     @test_logs (:warn, r"dispersion parameter") GeneralizedLinearMixedModel(form, dat, InverseGaussian())
     @test_logs (:warn, r"dispersion parameter") GeneralizedLinearMixedModel(form, dat, Normal(), SqrtLink())
+
+    # notes for future tests when GLMM with dispersion works
+    # @test dispersion_parameter(gm)
+    # @test dispersion(gm, false) == val
+    # @test dispersion(gm, true) == val
+    # @test sdest(gm) == dispersion(gm, false) == gm.σ
+    # @test varest(gm) == dispersion(gm, true)
 
 end

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -101,7 +101,7 @@ end
 
     @testset "Binomial  simulate!" begin
         gm2sim = refit!(simulate!(StableRNG(42), deepcopy(gm2)), fast=true)
-        @test all(isapprox.(gm2.β, gm2sim.β; atol=0.5))
+        @test isapprox(gm2.β, gm2sim.β; atol=norm(stderror(gm2)))
     end
 end
 
@@ -127,7 +127,7 @@ end
 
     @testset "Poisson  simulate!" begin
         gm4sim = refit!(simulate!(StableRNG(42), deepcopy(gm4)))
-        @test all(isapprox.(gm4.β, gm4sim.β; atol=0.5))
+        @test isapprox(gm4.β, gm4sim.β; atol=norm(stderror(gm4)))
     end
 
 end

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -9,6 +9,8 @@ using MixedModels: dataset
 include("modelcache.jl")
 
 @testset "contra" begin
+    contra = dataset(:contra)
+    gm0 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli(), fast=true)
     @test gm0.lowerbd == zeros(1)
     @test isapprox(gm0.θ, [0.5720734451352923], atol=0.001)
     @test !issingular(gm0)

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -127,7 +127,7 @@ end
 
     @testset "Poisson  simulate!" begin
         gm4sim = refit!(simulate!(StableRNG(42), deepcopy(gm4)))
-        @test all(isapprox.(gm4.β, gm4sim.β; atol=0.1))
+        @test all(isapprox.(gm4.β, gm4sim.β; atol=0.5))
     end
 
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,6 +1,6 @@
 using LinearAlgebra
 using MixedModels
-using Random
+using StableRNGs
 using SparseArrays
 using Test
 
@@ -15,7 +15,7 @@ end
 
 @testset "densify" begin
 	@test densify(sparse(1:5, 1:5, ones(5))) == Diagonal(ones(5))
-	rsparsev = SparseVector(float.(rand(MersenneTwister(123454321), Bool, 20)))
+	rsparsev = SparseVector(float.(rand(StableRNG(123454321), Bool, 20)))
 	@test densify(rsparsev) == Vector(rsparsev)
 	@test densify(Diagonal(rsparsev)) == Diagonal(Vector(rsparsev))
 end
@@ -36,14 +36,14 @@ end
 end
 
 @testset "threaded_replicate" begin
-	rng = MersenneTwister(42);
-	single_thread = replicate(10,use_threads=false) do; randn(rng, 1)[1] ; end
-	rng = MersenneTwister(42);
-	multi_thread = replicate(10,use_threads=true) do
+	rng = StableRNG(42);
+	single_thread = replicate(10;use_threads=false) do; only(randn(rng, 1)) ; end
+	rng = StableRNG(42);
+	multi_thread = replicate(10;use_threads=true) do
 		if Threads.threadid() % 2 == 0
 			sleep(0.001)
 		end
-		r = randn(rng, 1)[1];
+		r = only(randn(rng, 1));
 	end
 
 	@test all(sort!(single_thread) .== sort!(multi_thread))
@@ -61,11 +61,11 @@ end
 
 @testset "PCA" begin
 	pca = models(:kb07)[3].PCA.item
-	
+
 	show(io, pca, covcor=true, loadings=false)
 	str = String(take!(io))
 	@test !isempty(findall("load: yes", str))
-	
+
 	show(io, pca, covcor=false, loadings=true)
 	str = String(take!(io))
 	@test !isempty(findall("PC1", str))


### PR DESCRIPTION
Closes #245.

I had to add in a few accessor-to-preallocated-buffer methods for GLMM elsewhere (`fixef!`, etc.). 
~`stderror!` actually does a hidden allocation, but I'll fix that as soon as I've looked up `StatsBase.stderror`.~

~There's also still some debugging code in there, but it should otherwise be in a good state to check for conceptual errors.~
```
julia> using DataFrames

julia> using MixedModels

julia> using StableRNGs

julia> contra = MixedModels.dataset(:contra)
Arrow.Table: (dist = ["D01", "D01", "D01", "D01", "D01", "D01", "D01", "D01", "D01", "D01"  …  "D61", "D61", "D61", "D61", "D61", "D61", "D61", "D61", "D61", "D61"], urban = ["Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y", "Y"  …  "N", "N", "N", "N", "N", "N", "N", "N", "N", "N"], livch = ["3+", "0", "2", "3+", "0", "0", "3+", "3+", "1", "3+"  …  "1", "3+", "3+", "2", "2", "3+", "2", "3+", "0", "3+"], age = [18.44, -5.56, 1.44, 8.44, -13.56, -11.56, 18.44, -3.56, -5.56, 1.44  …  -5.56, 14.44, 19.44, -9.56, -2.56, 14.44, -4.56, 14.44, -13.56, 10.44], use = ["N", "N", "N", "N", "N", "N", "N", "N", "N", "N"  …  "N", "N", "N", "Y", "N", "N", "N", "N", "N", "N"])

julia> gm0 = fit(MixedModel, @formula(use ~ 1+age+abs2(age)+urban+livch+(1|urban&dist)), contra, Bernoulli(), fast=true);

julia> bs = parametricbootstrap(StableRNG(42), 1000, deepcopy(gm0));
Progress: 100%|███████████████████████████████████████ Time: 0:00:14

julia> combine(groupby(DataFrame(bs.β), :coefname), :β => first ∘ shortestcovint => :lower, :β => last ∘ shortestcovint => :upper)
7×3 DataFrame
│ Row │ coefname    │ lower       │ upper       │
│     │ Symbol      │ Float64     │ Float64     │
├─────┼─────────────┼─────────────┼─────────────┤
│ 1   │ (Intercept) │ -1.36078    │ -0.671704   │
│ 2   │ age         │ -0.01329    │ 0.0218545   │
│ 3   │ abs2(age)   │ -0.00565161 │ -0.00294269 │
│ 4   │ urban: Y    │ 0.439763    │ 1.09529     │
│ 5   │ livch: 1    │ 0.495756    │ 1.11646     │
│ 6   │ livch: 2    │ 0.493062    │ 1.23956     │
│ 7   │ livch: 3+   │ 0.549297    │ 1.23275     │

# CIs from the normal Wald approximation for comparison
julia> DataFrame(coef=fixefnames(gm0), lower=fixef(gm0) .- 2 .* stderror(gm0), upper=fixef(gm0) .+ 2 .* stderror(gm0))
7×3 DataFrame
│ Row │ coef        │ lower       │ upper       │
│     │ String      │ Float64     │ Float64     │
├─────┼─────────────┼─────────────┼─────────────┤
│ 1   │ (Intercept) │ -1.39311    │ -0.667259   │
│ 2   │ age         │ -0.0153779  │ 0.0218421   │
│ 3   │ abs2(age)   │ -0.00581783 │ -0.00289668 │
│ 4   │ urban: Y    │ 0.407463    │ 1.09011     │
│ 5   │ livch: 1    │ 0.486554    │ 1.14029     │
│ 6   │ livch: 2    │ 0.516467    │ 1.26265     │
│ 7   │ livch: 3+   │ 0.527929    │ 1.27843     │
```