### PR TITLE
Run CI on tag push, not on release creation

### DIFF
--- a/.github/workflows/Tier1.yml
+++ b/.github/workflows/Tier1.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - '*'
     paths-ignore:
       - 'LICENSE.md'
       - 'README.md'
@@ -12,9 +14,6 @@ on:
     paths-ignore:
       - 'LICENSE.md'
       - 'README.md'
-  release:
-    types:
-      - created
 jobs:
   ci:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
I think this is what Documenter needs in order to deploy documentation for tagged versions properly. Will hopefully fix stable docs issues.