### PR TITLE
Fix `propertynames` method ambiguity on Julia nightly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "3.0.0"
+version = "3.0.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -441,7 +441,7 @@ StatsBase.nobs(m::GeneralizedLinearMixedModel) = length(m.η)
 
 StatsBase.predict(m::GeneralizedLinearMixedModel) = fitted(m)
 
-Base.propertynames(m::GeneralizedLinearMixedModel, private = false) = (
+Base.propertynames(m::GeneralizedLinearMixedModel, private::Bool = false) = (
     :A,
     :L,
     :theta,

--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -19,7 +19,7 @@ struct LikelihoodRatioTest
     tests::NamedTuple{(:dofdiff,:deviancediff,:pvalues)}
 end
 
-Base.propertynames(lrt::LikelihoodRatioTest, private = false) = (
+Base.propertynames(lrt::LikelihoodRatioTest, private::Bool = false) = (
     :deviance,
     :formulas,
     :models,

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -570,7 +570,7 @@ end
 
 StatsBase.predict(m::LinearMixedModel) = fitted(m)
 
-Base.propertynames(m::LinearMixedModel, private = false) = (
+Base.propertynames(m::LinearMixedModel, private::Bool = false) = (
     :formula,
     :sqrtwts,
     :A,

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -211,7 +211,7 @@ function Base.getproperty(pca::PCA, s::Symbol)
     end
 end
 
-Base.propertynames(pca::PCA, private = false) = (
+Base.propertynames(pca::PCA, private::Bool = false) = (
     :covcor,
     :sv,
     :corr,


### PR DESCRIPTION
The ambiguity is between `propertynames(::Any, ::Bool)` and the overloads in this package `propertynames(::T, ::Any)` for various types `T`. Since the second argument should always be a `Bool` anyway, we can simply add the type annotation to the function signature to fix the ambiguity.