### PR TITLE
Check BLAS vendor, fix test warning, rephrase warn

### DIFF
--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -352,7 +352,7 @@ function GeneralizedLinearMixedModel(
     if !any(isa(d, dist) for dist in (Bernoulli, Binomial, Poisson))
         @warn """Results for families with a dispersion parameter are not reliable.
                  It is best to avoid trying to fit such models in MixedModels until
-                 the authors get a better understanding of those cases."""
+                 the authors gain a better understanding of those cases."""
     end
 
     LMM = LinearMixedModel(f, tbl, contrasts = contrasts; wts = wts)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,10 @@ import LinearAlgebra: BLAS
 
 # there seem to be processor-specific issues and knowing this is helpful
 println(versioninfo())
-println(BLAS.openblas_get_config())
+@show BLAS.vendor()
+if BLAS.vendor() == :openblas
+    println(BLAS.openblas_get_config())
+end
 
 include("utilities.jl")
 include("pivot.jl")

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -6,7 +6,6 @@ using Test
 
 using MixedModels: allequal, average, densify, dataset
 
-const io = IOBuffer()
 include("modelcache.jl")
 
 @testset "average" begin
@@ -60,6 +59,7 @@ end
 end
 
 @testset "PCA" begin
+	io = IOBuffer()
 	pca = models(:kb07)[3].PCA.item
 
 	show(io, pca, covcor=true, loadings=false)


### PR DESCRIPTION
- Tests were failing under MKL because `openblas_get_config()` is not defined.
- Rephrase a warning message
- Move definition of `io` inside a `testset` in `test/utilities.jl` to avoid later warning on redefinition in `test/pls.jl`.