### PR TITLE
loosen floating point equality constraint

### DIFF
--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -45,7 +45,7 @@ end
 		r = only(randn(rng, 1));
 	end
 
-	@test all(sort!(single_thread) .== sort!(multi_thread))
+	@test all(sort!(single_thread) .≈ sort!(multi_thread))
 end
 
 @testset "datasets" begin


### PR DESCRIPTION
There is a very weird race condition that seems to arise in Julia 1.5 and which I can't consistently replicate.  I'm pretty sure the locking is correct. I suspect it's actually a floating point issue interacting in a fun way with threading. If it were only Julia threads there, then you would have the exact same floating point operations for each iteration, but the iterations potentially out of order (hence the sorting). But I think some of layers of optimization are breaking that assumption and that test should be made approximate but with a tight tolerance.