### PR TITLE
Force BlasInt type for piv

### DIFF
--- a/src/linalg/pivot.jl
+++ b/src/linalg/pivot.jl
@@ -10,7 +10,7 @@ function statscholesky(xtx::Symmetric{T}, tol::Real = -1) where {T<:AbstractFloa
     chpiv = cholesky(xtx, Val(true), tol = T(tol), check = false)
     chunp = cholesky(xtx, check = false);
 
-    piv = [1:n;]
+    piv = LinearAlgebra.BlasInt.(collect(1:n))
     r = chpiv.rank
 
     if r < n
@@ -58,7 +58,7 @@ function statsqr(x::Matrix{T}; ranktol=1e-8) where {T<:AbstractFloat}
     if rank < n
         piv = qrpiv.p
     else
-        piv = collect(1:n)
+        piv = LinearAlgebra.BlasInt.(collect(1:n))
     end
 
     if rank < n && piv[1] ≠ 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ import LinearAlgebra: BLAS
 # there seem to be processor-specific issues and knowing this is helpful
 println(versioninfo())
 @show BLAS.vendor()
-if BLAS.vendor() == :openblas
+if startswith(string(BLAS.vendor()), "openblas")
     println(BLAS.openblas_get_config())
 end
 


### PR DESCRIPTION
When using [`MKL`](https://github.com/JuliaComputing/MKL.jl) on a 64-bit Ubuntu system I found that I needed to set
```
ENV["USE_BLAS64"]=true
```
before building `MKL` or there would be a missing method error in the call to `QRPivoted`.  I believe that, by default, MKL uses 32-bit integers but OpenBLAS uses 64-bit integers.  The `piv` vector was being constructed as `collect(1:n)` hence it would default to 64-bit integers.

I think it is because the second external constructor for `QRPivoted` in the `LinearAlgebra` package
```
function QRPivoted{T}(factors::AbstractMatrix, τ::AbstractVector, jpvt::AbstractVector) where {T}
    QRPivoted(convert(AbstractMatrix{T}, factors),
              convert(Vector{T}, τ),
              convert(Vector{BlasInt}, jpvt))
end
```
which would change the eltype of `jpvt` isn't being called in this case.  IIUC it would need to be called with an explicit type `T`, as in
```
QRPivoted{Float64}(...)
```
because `T` can't be inferred from the arguments to the function.

@andreasnoack Does this make sense?


I threw in a second change related to MKL.  I thought that the symbol returned from `BLAS.vendor()` was `:openblas` but, in fact, it is `:openblas64` or `:openblas32`.  Should the symbol returned for MKL also be changed to `:mkl32` or `:mkl64`?
