### PR TITLE
categorical! no longer in DataFrames 0.22

### DIFF
--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -1,5 +1,6 @@
 using DataFrames
 using MixedModels
+using PooledArrays
 using StableRNGs
 using Tables
 using Test
@@ -119,24 +120,20 @@ end
 end
 
 @testset "goldstein" begin # from a 2020-04-22 msg by Ben Goldstein to R-SIG-Mixed-Models
-    goldstein =
-        categorical!(
-            DataFrame(
-                group = repeat(1:10, outer=10),
-                y = [
-                    83, 3, 8, 78, 901, 21, 4, 1, 1, 39,
-                    82, 3, 2, 82, 874, 18, 5, 1, 3, 50,
-                    87, 7, 3, 67, 914, 18, 0, 1, 1, 38,
-                    86, 13, 5, 65, 913, 13, 2, 0, 0, 48,
-                    90, 5, 5, 71, 886, 19, 3, 0, 2, 32,
-                    96, 1, 1, 87, 860, 21, 3, 0, 1, 54,
-                    83, 2, 4, 70, 874, 19, 5, 0, 4, 36,
-                    100, 11, 3, 71, 950, 21, 6, 0, 1, 40,
-                    89, 5, 5, 73, 859, 29, 3, 0, 2, 38,
-                    78, 13, 6, 100, 852, 24, 5, 0, 1, 39
-                    ],
-                ),
-            :group,
+    goldstein = (
+        group = PooledArray(repeat(string.('A':'J'), outer=10)),
+        y = [
+            83, 3, 8, 78, 901, 21, 4, 1, 1, 39,
+            82, 3, 2, 82, 874, 18, 5, 1, 3, 50,
+            87, 7, 3, 67, 914, 18, 0, 1, 1, 38,
+            86, 13, 5, 65, 913, 13, 2, 0, 0, 48,
+            90, 5, 5, 71, 886, 19, 3, 0, 2, 32,
+            96, 1, 1, 87, 860, 21, 3, 0, 1, 54,
+            83, 2, 4, 70, 874, 19, 5, 0, 4, 36,
+            100, 11, 3, 71, 950, 21, 6, 0, 1, 40,
+            89, 5, 5, 73, 859, 29, 3, 0, 2, 38,
+            78, 13, 6, 100, 852, 24, 5, 0, 1, 39
+            ],
         )
     gform = @formula(y ~ 1 + (1|group))
     m1 = fit(MixedModel, gform, goldstein, Poisson())


### PR DESCRIPTION
Drop the call to `categorical!` in `test/pirls.jl`.  Also clean up the example a bit using `PooledArray` instead of a `CategoricalArray`.