### PR TITLE
Eagerness to avoid LazyArtifacts 

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -10,7 +10,7 @@
 # println("git-tree-sha1: ", Tar.tree_hash(IOBuffer(inflate_gzip(filename))))
 # from https://julialang.github.io/Pkg.jl/dev/artifacts/
 git-tree-sha1 = "75260d131b693f26e5834adf855f4c35d627348d"
-lazy = true
+lazy = false
 
     [[TestData.download]]
     # this is the SHA from https://osf.io/djaqb/download?version=4

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -8,7 +8,7 @@ using GLM
 using LinearAlgebra
 using NLopt
 using Random
-using Pkg.Artifacts
+using Pkg
 using PooledArrays
 using ProgressMeter
 using SparseArrays

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -8,7 +8,7 @@ using GLM
 using LinearAlgebra
 using NLopt
 using Random
-using Pkg
+using Pkg.Artifacts
 using PooledArrays
 using ProgressMeter
 using SparseArrays
@@ -17,6 +17,14 @@ using Statistics
 using StatsBase
 using StatsModels
 using Tables
+
+# When we move to 1.6 as the support lower minimum, we should change Artifact.toml to be lazy
+# and add LazyArtifacts to our dependencies
+# @static if VERSION > v"1.6.0-DEV.1588" # the actual bound may be lower
+#     @warn """Loading LazyArtifacts
+#              This will generate a dependency warning until compatibility with Julia 1.4+1.5 is removed"""
+#     using LazyArtifacts
+# end
 
 using LinearAlgebra: BlasFloat, BlasReal, HermOrSym, PosDefException, copytri!
 using Base: Ryu


### PR DESCRIPTION
It seems challenging to have lazy artifact downloading be compatible with Julia < 1.6 and 1.6+, see recent test failures and [Discourse](https://discourse.julialang.org/t/recommended-transition-to-lazyartifacts/). However, we use the `TestData` artifact in `__init__` so they're downloaded with the very first `using MixedModels`, which we can assume most users will want to do not too much after `]add MixedModels`. So we can avoid all the laziness issues and just be eager. Slightly longer download times upon initial install, but since the artifacts system has its own caching, there shouldn't be any real performance issues as long as we don't change `TestData` too often.