### PR TITLE
Use vector of matrices for A and L in LinearMixedModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "3.1.4"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
-BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
@@ -25,7 +24,6 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Arrow = "1"
-BlockArrays = "0.11, 0.12, 0.13"
 DataAPI = "1"
 Distributions = "0.21, 0.22, 0.23, 0.24"
 GLM = "1"

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -1,7 +1,6 @@
 module MixedModels
 
 using Arrow
-using BlockArrays
 using DataAPI
 using Distributions
 using GLM
@@ -42,7 +41,6 @@ export @formula,
        AbstractReMat,
        Bernoulli,
        Binomial,
-       Block,
        BlockDescription,
        BlockedSparse,
        DummyCoding,

--- a/src/blockdescription.jl
+++ b/src/blockdescription.jl
@@ -25,11 +25,11 @@ function BlockDescription(m::LinearMixedModel)
     ALtypes = fill("", k, k)
     Ltypes = fill(Nothing, k, k)
     for i in 1:k, j in 1:i
-        ALtypes[i, j] = shorttype(getblock(A, i,j), getblock(L, i,j))
+        ALtypes[i, j] = shorttype(A[packedlowertri(i,j)], L[packedlowertri(i, j)])
     end
     BlockDescription(
         blknms,
-        [size(getblock(A, i, 1), 1) for i in 1:k],
+        [size(A[kp1choose2(i)], 1) for i in 1:k],
         ALtypes,
      )
 end

--- a/src/blockdescription.jl
+++ b/src/blockdescription.jl
@@ -25,7 +25,7 @@ function BlockDescription(m::LinearMixedModel)
     ALtypes = fill("", k, k)
     Ltypes = fill(Nothing, k, k)
     for i in 1:k, j in 1:i
-        ALtypes[i, j] = shorttype(A[packedlowertri(i,j)], L[packedlowertri(i, j)])
+        ALtypes[i, j] = shorttype(A[block(i,j)], L[block(i, j)])
     end
     BlockDescription(
         blknms,

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -89,7 +89,7 @@ function StatsBase.deviance(m::GeneralizedLinearMixedModel{T}, nAGQ = 1) where {
     copyto!(u₀, u)
     ra = RaggedArray(m.resp.devresid, first(m.LMM.allterms).refs)
     devc0 = sum!(map!(abs2, m.devc0, u), ra)  # the deviance components at z = 0
-    sd = map!(inv, m.sd, getblock(m.LMM.L, 1, 1).diag)
+    sd = map!(inv, m.sd, first(m.LMM.L).diag)
     mult = fill!(m.mult, 0)
     devc = m.devc
     for (z, w) in GHnorm(nAGQ)
@@ -519,7 +519,7 @@ function pirls!(
         println()
     end
     for iter = 1:maxiter
-        varyβ && ldiv!(adjoint(feL(m)), copyto!(β, lm.L.blocks[end, end-1]))
+        varyβ && ldiv!(adjoint(feL(m)), copyto!(β, lm.L[end-1]))
         ranef!(u, m.LMM, β, true) # solve for new values of u
         obj = deviance!(m)        # update GLM vecs and evaluate Laplace approx
         verbose && println(lpad(iter, 4), ": ", obj)

--- a/src/linalg/logdet.jl
+++ b/src/linalg/logdet.jl
@@ -26,9 +26,9 @@ lower Cholesky factor.
 function LinearAlgebra.logdet(m::LinearMixedModel{T}) where {T}
     L = m.L
     nre = m.dims.nretrms
-    s = LD(getblock(L, 1,1))
+    s = LD(first(L))
     for j in 2:nre
-        s += LD(getblock(L, j, j))
+        s += LD(L[kp1choose2(j)])
     end
     if m.optsum.REML
         feindex = nre + 1

--- a/src/linalg/logdet.jl
+++ b/src/linalg/logdet.jl
@@ -31,8 +31,7 @@ function LinearAlgebra.logdet(m::LinearMixedModel{T}) where {T}
         s += LD(L[kp1choose2(j)])
     end
     if m.optsum.REML
-        feindex = nre + 1
-        s += LD(getblock(L, feindex, feindex))
+        s += LD(L[kp1choose2(nre + 1)])
     end
     s + s
 end

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -946,7 +946,9 @@ function updateL!(m::LinearMixedModel{T}) where {T}
     A = m.A
     L = m.L
     k = length(m.allterms)
-    copy!.(L, A)            # copy each element of A to corresponding element of L
+    for (l, a) in zip(L, A) # copy each element of A to corresponding element of L
+        copyto!(l, a)       # For some reason copyto!.(L, A) allocates a lot of memory
+    end
     for (j, cj) in enumerate(m.reterms)  # pre- and post-multiply by Λ, add I to diagonal
         scaleinflate!(L[kp1choose2(j)], cj)
         for i = (j+1):k         # postmultiply column by Λ

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -92,6 +92,41 @@ function rownormalize!(A::AbstractMatrix)
 end
 
 """
+    kchoose2(k)
+
+The binomial coefficient `k` choose `2` which is the number of elements
+in the packed form of the strict lower triangle of a matrix.
+"""
+function kchoose2(k)      # will be inlined
+    (k * (k - 1)) >> 1
+end
+
+"""
+    kp1choose2(k)
+
+The binomial coefficient `k+1` choose `2` which is the number of elements
+in the packed form of the lower triangle of a matrix.
+"""
+function kp1choose2(k)
+    (k * (k + 1)) >> 1
+end
+
+"""
+    packedlowertri(i, j)
+
+Return the linear index of the `[i,j]` position in the row-major packed lower triangle.
+
+Use the row-major ordering in this case because the result depends only on `i`
+and `j`, not on the overall size of the array.
+
+When `i == j` the value is the same as `kp1choose2(i)`.
+"""
+function packedlowertri(i::Integer, j::Integer)
+    0 < j ≤ i || throw(ArgumentError("[i,j] = [$i,$j] must be in the lower triangle"))
+    kchoose2(i) + j
+end
+
+"""
     ltriindprs
 
 A row-major order `Vector{NTuple{2,Int}}` of indices in the strict lower triangle.
@@ -99,9 +134,9 @@ A row-major order `Vector{NTuple{2,Int}}` of indices in the strict lower triangl
 const ltriindprs = NTuple{2,Int}[]
 
 function checkindprsk(k::Integer)
-    kchoose2 = (k * (k - 1)) >> 1
-    if length(ltriindprs) < kchoose2
-        sizehint!(empty!(ltriindprs), kchoose2)
+    kc2 = kchoose2(k)
+    if length(ltriindprs) < kc2
+        sizehint!(empty!(ltriindprs), kc2)
         for i in 1:k, j in 1:(i-1)
             push!(ltriindprs, (i,j))
         end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -112,16 +112,16 @@ function kp1choose2(k)
 end
 
 """
-    packedlowertri(i, j)
+    block(i, j)
 
-Return the linear index of the `[i,j]` position in the row-major packed lower triangle.
+Return the linear index of the `[i,j]` position ("block") in the row-major packed lower triangle.
 
 Use the row-major ordering in this case because the result depends only on `i`
 and `j`, not on the overall size of the array.
 
 When `i == j` the value is the same as `kp1choose2(i)`.
 """
-function packedlowertri(i::Integer, j::Integer)
+function block(i::Integer, j::Integer)
     0 < j ≤ i || throw(ArgumentError("[i,j] = [$i,$j] must be in the lower triangle"))
     kchoose2(i) + j
 end
@@ -288,16 +288,16 @@ function Base.show(io::IO, pca::PCA;
             if any(neg)
                 cv[.!neg] .= " ".* cv[.!neg]
             end
-            # this hurts type stability, 
+            # this hurts type stability,
             # but this show method shouldn't be a bottleneck
             printmat = Text.([pca.rnames cv])
         else
             # if there are no names, then we cheat and use the print method
-            # for LowerTriangular, which automatically covers the . in the 
+            # for LowerTriangular, which automatically covers the . in the
             # upper triangle
             printmat = round.(LowerTriangular(pca.covcor), digits=ndigitsmat)
         end
-        
+
         Base.print_matrix(io, printmat)
         println(io)
     end
@@ -319,15 +319,15 @@ function Base.show(io::IO, pca::PCA;
     if loadings
         println(io, "\nComponent loadings")
         printmat = round.(pca.loadings, digits=ndigitsmat)
-        
-        if pca.rnames !== missing 
+
+        if pca.rnames !== missing
             pclabs = [Text(""); Text.( "PC$i" for i in 1:length(pca.rnames))]
             pclabs = reshape(pclabs, 1, :)
-            # this hurts type stability, 
+            # this hurts type stability,
             # but this show method shouldn't be a bottleneck
             printmat = [pclabs; Text.(pca.rnames) printmat]
         end
-            
+
         Base.print_matrix(io, printmat)
     end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 GLM = "38e38edf-8417-5370-95a0-9cbb8c7f171a"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -409,7 +409,7 @@ end
 @testset "oxide" begin
     # this model has an interesting structure with two diagonal blocks
     m = first(models(:oxide))
-    @test all(isapprox.(m.θ, [1.689182746, 2.98504262]; atol=1e-4))
+    @test isapprox(m.θ, [1.689182746, 2.98504262]; atol=1e-3)
     m = last(models(:oxide))
     # NB: this is a poorly defined fit
     # lme4 gives all sorts of convergence warnings for the different

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -1,4 +1,3 @@
-using BlockArrays
 using LinearAlgebra
 using MixedModels
 using PooledArrays
@@ -245,17 +244,17 @@ end
 @testset "sleep" begin
     fm = last(models(:sleepstudy))
     @test lowerbd(fm) == [0.0, -Inf, 0.0]
-    A11 = getblock(fm.A, 1,1)
+    A11 = first(fm.A)
     @test isa(A11, UniformBlockDiagonal{Float64})
-    @test isa(getblock(fm.L, 1, 1), UniformBlockDiagonal{Float64})
+    @test isa(first(fm.L), UniformBlockDiagonal{Float64})
     @test size(A11) == (36, 36)
     a11 = view(A11.data, :, :, 1)
     @test a11 == [10. 45.; 45. 285.]
     @test size(A11.data, 3) == 18
     λ = first(fm.λ)
-    b11 = LowerTriangular(view(getblock(fm.L, 1, 1).data, :, :, 1))
+    b11 = LowerTriangular(view(first(fm.L).data, :, :, 1))
     @test b11 * b11' ≈ λ'a11*λ + I rtol=1e-5
-    @test count(!iszero, Matrix(getblock(fm.L, 1, 1))) == 18 * 4
+    @test count(!iszero, Matrix(first(fm.L))) == 18 * 4
     @test rank(fm) == 2
 
     @test objective(fm) ≈ 1751.9393444647046


### PR DESCRIPTION
- `BlockArray`s were only being used to store and access different matrices that formed the blocks of the `A` and `L` components of a `LinearMixedModel` object.
- Replace the `BlockArray`s with  `Vector{AbstractMatrix{T}}` and functions to convert an `[i,j]` index in the lower triangle to an index into the vector
- Within the vector, the blocks in the lower triangle are stored in _row-major_ order because this simplifies the conversion of row-column to linear index
- Because this change will require a new major release number will consider also changing to a single `Xy` block instead of separate blocks.  Nothing in the update of the Cholesky factor requires separate handling of the blocks associated with `X` and with `y`. 