### PR TITLE
Runtime random effect terms (and zerocorr)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,17 @@ MixedModels v4.0.0 Release Notes
   and make `MixedModelBootstrap` a subtype of it. Accordingly, rename the `bstr`
   field to `fits`. [#465]
 
+Run-time formula syntax
+-----------------------
+
+* It is now possible to construct `RandomEffectsTerm`s at run-time from `Term`s
+  (methods for `Base.|(::AbstractTerm, ::AbstractTerm)` added) [#470]
+* `RandomEffectsTerm`s can have left- and right-hand side terms that are
+  "non-concrete", and `apply_schema(::RandomEffectsTerm, ...)` works more like
+  other StatsModels.jl `AbstractTerm`s [#470]
+* Methods for `Base./(::AbstractTerm, ::AbstractTerm)` are added, allowing
+  nesting syntax to be used with `Term`s at run-time as well [#470]
+
 MixedModels v3.1.4 Release Notes
 ========================
 * [experimental] Additional convenience constructors for `LinearMixedModel` [#449]

--- a/docs/src/constructors.md
+++ b/docs/src/constructors.md
@@ -27,12 +27,33 @@ dyestuff = DataFrame(MixedModels.dataset(:dyestuff))
 describe(dyestuff)
 ```
 
-### Models with simple, scalar random effects
+### The `@formula` language in Julia
 
-The formula language in *Julia* is similar to that in *R* which is based on (Wilkinson and Rogers [1973](https://dx.doi.org/10.2307/2346786)). In Julia a formula must be enclosed in a call to the `@formula` macro.
+MixedModels.jl builds on the the *Julia* formula language provided by [StatsModels.jl](https://juliastats.org/StatsModels.jl/stable/formula/), which is similar to the formula language in *R* and is also based on (Wilkinson and Rogers [1973](https://dx.doi.org/10.2307/2346786)). There are two ways to construct a formula in *Julia*.  The first way is to enclose the formula expression in the `@formula` macro:
 ```@docs
 @formula
 ```
+
+The second way is to combine `Term`s with operators like `+`, `&`, `~`, and others at "run time".  This is especially useful if you wish to create a formula from a list a variable names.  For instance, the following are equivalent:
+
+```@example Main
+@formula(y ~ 1 + a + b + a & b) == term(:y) ~ term(1) + term(:a) + term(:b) + term(:a) & term(:b)
+```
+
+MixedModels.jl provides additional formula syntax for representing *random-effects terms*.  Most importantly, `|` separates random effects and their grouping factors (as in the formula extension used by the *R* package [`lme4`](https://cran.r-project.org/web/packages/lme4/index.html).  Much like with the base formula language, `|` can be used within the `@formula` macro and to construct a formula programmatically:
+
+```@example Main
+@formula(y ~ 1 + a + b + (1 + a + b | g))
+```
+
+```@example Main
+terms = sum(term(t) for t in [1, :a, :b])
+group = term(:g)
+response = term(:y)
+response ~ terms + (terms | group)
+```
+
+### Models with simple, scalar random effects
 
 A basic model with simple, scalar random effects for the levels of `batch` (the batch of an intermediate product, in this case) is declared and fit as
 

--- a/docs/src/constructors.md
+++ b/docs/src/constructors.md
@@ -29,7 +29,7 @@ describe(dyestuff)
 
 ### The `@formula` language in Julia
 
-MixedModels.jl builds on the the *Julia* formula language provided by [StatsModels.jl](https://juliastats.org/StatsModels.jl/stable/formula/), which is similar to the formula language in *R* and is also based on (Wilkinson and Rogers [1973](https://dx.doi.org/10.2307/2346786)). There are two ways to construct a formula in *Julia*.  The first way is to enclose the formula expression in the `@formula` macro:
+MixedModels.jl builds on the the *Julia* formula language provided by [StatsModels.jl](https://juliastats.org/StatsModels.jl/stable/formula/), which is similar to the formula language in *R* and is also based on the notation from Wilkinson and Rogers ([1973](https://dx.doi.org/10.2307/2346786)). There are two ways to construct a formula in Julia.  The first way is to enclose the formula expression in the `@formula` macro:
 ```@docs
 @formula
 ```
@@ -556,4 +556,3 @@ fm4r = fit(MixedModel, @formula(diameter ~ 1+(1|plate)+(1|sample)),
 ```@example Main
 sum(leverage(fm4r))
 ```
-

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -22,6 +22,8 @@ function StatsModels.termvars(t::RandomEffectsTerm)
     vcat(StatsModels.termvars(t.lhs), StatsModels.termvars(t.rhs))
 end
 
+StatsModels.terms(t::RandomEffectsTerm) = union(StatsModels.terms(t.lhs), StatsModels.terms(t.rhs))
+
 # | in MixedModel formula -> RandomEffectsTerm
 function StatsModels.apply_schema(
     t::FunctionTerm{typeof(|)},

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -194,12 +194,24 @@ Remove correlations between random effects in `term`.
 """
 zerocorr(x) = ZeroCorr(x)
 
+# for schema extraction (from runtime-created zerocorr)
+StatsModels.terms(t::ZeroCorr) = StatsModels.terms(t.term)
+StatsModels.termvars(t::ZeroCorr) = StatsModels.termvars(t.term)
+
 function StatsModels.apply_schema(
     t::FunctionTerm{typeof(zerocorr)},
     sch::MultiSchema,
     Mod::Type{<:MixedModel},
 )
     ZeroCorr(apply_schema(t.args_parsed..., sch, Mod))
+end
+
+function StatsModels.apply_schema(
+    t::ZeroCorr,
+    sch::MultiSchema,
+    Mod::Type{<:MixedModel},
+)
+    ZeroCorr(apply_schema(t.term, sch, Mod))
 end
 
 StatsModels.modelcols(t::ZeroCorr, d::NamedTuple) = zerocorr!(modelcols(t.term, d))

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -120,8 +120,8 @@ function _ranef_refs(
     refs, uniques
 end
 
-
-
+# TODO: split this off into a RegressionFormula packge?
+Base.:/(a::AbstractTerm, b::AbstractTerm) = a + a & b
 function StatsModels.apply_schema(
     t::FunctionTerm{typeof(/)},
     sch::StatsModels.FullRank,
@@ -139,9 +139,6 @@ function StatsModels.apply_schema(
 
     return first + fulldummy(first) & second
 end
-
-
-
 
 # add some syntax to manually promote to full dummy coding
 fulldummy(t::AbstractTerm) =

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -12,7 +12,7 @@ end
 Base.:|(a::StatsModels.TermOrTerms, b::StatsModels.TermOrTerms) = RandomEffectsTerm(a, b)
 
 # expand (lhs | a + b) to (lhs | a) + (lhs | b)
-RandomEffectsTerm(lhs, rhs::NTuple{2,AbstractTerm}) =
+RandomEffectsTerm(lhs::StatsModels.TermOrTerms, rhs::NTuple{2,AbstractTerm}) =
     (RandomEffectsTerm(lhs, rhs[1]), RandomEffectsTerm(lhs, rhs[2]))
 
 Base.show(io::IO, t::RandomEffectsTerm) = print(io, "($(t.lhs) | $(t.rhs))")

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -233,7 +233,9 @@ end
         # runtime
         fr2 = term(1) + term(:b) / term(:a)
         @test length(fr2) == 3
-        @test all(typeof.(fr2) .<: (ConstantTerm, Term, InteractionTerm))
+        @test fr2[1] isa ConstantTerm
+        @test fr2[2] isa Term
+        @test fr2[3] isa InteractionTerm
         frf2 = apply_schema(term(0) ~ fr2, schema(d2), MixedModel)
         @test modelcols(frf2.rhs, d2) == [ones(20) d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
         @test coefnames(frf2.rhs) == ["(Intercept)", "b: Y", "b: X & a", "b: Y & a"]
@@ -246,7 +248,9 @@ end
         # runtime:
         fr3 = term(0) + term(:b) / term(:a)
         @test length(fr3) == 3
-        @test all(typeof.(fr3) .<: (ConstantTerm, Term, InteractionTerm))
+        @test fr3[1] isa ConstantTerm
+        @test fr3[2] isa Term
+        @test fr3[3] isa InteractionTerm
         ffr3 = apply_schema(term(0) ~ fr3, schema(d2), MixedModel)
         @test modelcols(ffr3.rhs, d2) == [d2.b .== :X d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
         @test coefnames(ffr3.rhs) == ["b: X", "b: Y", "b: X & a", "b: Y & a"]

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -120,6 +120,9 @@ end
         m1 = fit(LMM, f1, slp)
         m2 = fit(LMM, f2, slp)
         @test all(m1.λ .== m2.λ)
+
+        @test StatsModels.terms(f2.rhs[end]) == [one, d, s]
+        @test StatsModels.termvars(f2.rhs[end]) == [d.sym, s.sym]
     end
 
     @testset "Runtime construction of ZeroCorr" begin
@@ -140,6 +143,9 @@ end
         m1 = fit(LMM, f1, slp)
         m2 = fit(LMM, f2, slp)
         @test all(m1.λ .== m2.λ)
+
+        @test StatsModels.terms(f2.rhs[end]) == [one, d, s]
+        @test StatsModels.termvars(f2.rhs[end]) == [d.sym, s.sym]
     end
     
 end

--- a/test/FactorReTerm.jl
+++ b/test/FactorReTerm.jl
@@ -230,9 +230,26 @@ end
         @test modelcols(f2.rhs, d2) == [ones(20) d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
         @test coefnames(f2.rhs) == ["(Intercept)", "b: Y", "b: X & a", "b: Y & a"]
 
+        # runtime
+        fr2 = term(1) + term(:b) / term(:a)
+        @test length(fr2) == 3
+        @test all(typeof.(fr2) .<: (ConstantTerm, Term, InteractionTerm))
+        frf2 = apply_schema(term(0) ~ fr2, schema(d2), MixedModel)
+        @test modelcols(frf2.rhs, d2) == [ones(20) d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
+        @test coefnames(frf2.rhs) == ["(Intercept)", "b: Y", "b: X & a", "b: Y & a"]
+
+        # check promotion
         f3 = apply_schema(@formula(0 ~ 0 + b/a), schema(d2), MixedModel)
         @test modelcols(f3.rhs, d2) == [d2.b .== :X d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
         @test coefnames(f3.rhs) == ["b: X", "b: Y", "b: X & a", "b: Y & a"]
+
+        # runtime:
+        fr3 = term(0) + term(:b) / term(:a)
+        @test length(fr3) == 3
+        @test all(typeof.(fr3) .<: (ConstantTerm, Term, InteractionTerm))
+        ffr3 = apply_schema(term(0) ~ fr3, schema(d2), MixedModel)
+        @test modelcols(ffr3.rhs, d2) == [d2.b .== :X d2.b .== :Y (d2.b .== :X).*d2.a (d2.b .== :Y).*d2.a]
+        @test coefnames(ffr3.rhs) == ["b: X", "b: Y", "b: X & a", "b: Y & a"]
 
         # errors for continuous grouping
         @test_throws ArgumentError apply_schema(@formula(0 ~ 1 + a/b), schema(d2), MixedModel)
@@ -244,10 +261,12 @@ end
         psts = dataset("pastes")
         m = fit(MixedModel, @formula(strength ~ 1 + (1|batch/cask)), psts)
         m2 = fit(MixedModel, @formula(strength ~ 1 + (1|batch) + (1|batch&cask)), psts)
+        mr = fit(MixedModel, term(:strength) ~ term(1) + (term(1)|term(:batch)/term(:cask)), psts)
+        m2r = fit(MixedModel, term(:strength) ~ term(1) + (term(1)|term(:batch)) + (term(1)|term(:batch)&term(:cask)), psts)
 
-        @test fnames(m) == fnames(m2) == (Symbol("batch & cask"), :batch)
-        @test m.λ == m2.λ
-        @test deviance(m) == deviance(m2)
+        @test fnames(m) == fnames(m2) == fnames(mr) == fnames(m2r) == (Symbol("batch & cask"), :batch)
+        @test m.λ == m2.λ == mr.λ == m2r.λ
+        @test deviance(m) == deviance(m2) == deviance(mr) == deviance(m2r)
     end
 
     @testset "multiple terms with same grouping" begin


### PR DESCRIPTION
This fixes #462 and more or less follows the plan outlined there: it adds a
method for `Base.:|` for two terms which returns a `RandomEffectsTerm`, and adds
an additional layer of indirection for `apply_schema` to operate on the
"untyped" `RandomEffectsTerm`s created by that process.  I've also made the
analogous changes to `zerocorr` (although that runtime method was actually
already in place, it didn't, you know, work...)

To my mind, the one big wart here is that we're "claiming"
`Base.:|(::TermOrTerms, ::TermOrTerms)` which wouldn't play nicely with another
package that also wants to provide a different set of semantics for `|` (at
run-time).  I first thought that we could do the same trick that
FilePathsBase.jl does with `/` (creating a new `/` function that falls back to
`Base./` for arguments of types it doesn't own) but that didn't seem to work (I
got an "ignoring conflicting import" when doing `using MixedModels: |` with that
strategy).