### PR TITLE
QR-Based Rank Determination and Pivoting

### DIFF
--- a/.github/workflows/MKL.yml
+++ b/.github/workflows/MKL.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1.5]
+        julia-version: [nightly]
         julia-arch: [x64]
         os: [ubuntu-18.04]
     steps:

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ MixedModels v4.0.0 Release Notes
 * Introduce an abstract type for collections of fits `MixedModelFitCollection`,
   and make `MixedModelBootstrap` a subtype of it. Accordingly, rename the `bstr`
   field to `fits`. [#465]
+* Replace internal `statscholesky` and `statsqr` functions for determining the 
+  rank of `X` by `statsrank`. [#479]
 
 Run-time formula syntax
 -----------------------

--- a/src/Xymat.jl
+++ b/src/Xymat.jl
@@ -33,18 +33,14 @@ function FeTerm(X::AbstractMatrix{T}, cnms) where {T}
     if iszero(size(X, 2))
         return FeTerm{T,typeof(X)}(X, Int[], 0, cnms)
     end
-    st = statsqr(X)
-    pivot = st.p
-    rank = findfirst(<=(0), diff(st.p))
-    rank = isnothing(rank) ? length(pivot) : rank
-    Xp = pivot == collect(1:size(X, 2)) ? X : X[:, pivot]
+    rank, pivot = statsrank(X)
         # single-column rank deficiency is the result of a constant column vector
         # this generally happens when constructing a dummy response, so we don't
         # warn.
     if rank < length(pivot) && size(X,2) > 1
         @warn "Fixed-effects matrix is rank deficient"
     end
-    FeTerm{T,typeof(X)}(Xp, pivot, rank, cnms[pivot])
+    FeTerm{T,typeof(X)}(X[:, pivot], pivot, rank, cnms[pivot])
 end
 
 """

--- a/src/linalg/pivot.jl
+++ b/src/linalg/pivot.jl
@@ -1,35 +1,36 @@
 """
-    statsqr(x::Matrix{T}, ranktol::Real=1e-8) where {T<:AbstractFloat}
+    statsrank(x::Matrix{T}, ranktol::Real=1e-8) where {T<:AbstractFloat}
 
-Return the numerical column rank and, for a rank-deficient X, a pivot vector
+Return the numerical column rank and a pivot vector.
+
+The rank is determined from the absolute values of the diagonal of R from
+a pivoted QR decomposition, relative to the first (and, hence, largest) 
+element of this vector.
+
+In the full-rank case the pivot vector is `collect(axes(x, 2))`.
 """
-function statsqr(x::Matrix{T}; ranktol=1e-8) where {T<:AbstractFloat}
-    n = size(x, 2)
+function statsrank(x::AbstractMatrix{T}; ranktol=1e-8) where {T<:AbstractFloat}
+    m, n = size(x)
 
     qrpiv = qr(x, Val(true))
-    rank =  searchsortedlast(abs.(diag(qrpiv.R)), ranktol, rev=true);
-    if rank < n
-        piv = qrpiv.p
-    else
-        piv = LinearAlgebra.BlasInt.(collect(1:n))
+    dvec = abs.(diag(qrpiv.R))
+    fdv = first(dvec)
+    if (last(dvec) / fdv) > ranktol
+        return (rank = n, piv = collect(axes(x, 2)))
     end
-
-    if rank < n && piv[1] ≠ 1
-        # make sure the first column isn't moved
-        # this is usually the intercept and it's desirable to avoid
-        # pivoting the intercept out. note that this inflation may
-        # not always be enough, but if it isn't, then you probably
-        # have other problems
-
-        x = deepcopy(x) # this is horrible
-        x[:, 1] .*= 1e6
+    rank = searchsortedlast(dvec ./ fdv, ranktol, rev=true)
+    @assert rank < n
+    piv = qrpiv.p
+    v1 = first(eachcol(x))
+    if all(isone, v1) && first(piv) ≠ 1
+        # make sure the first column isn't moved by inflating v1
+        v1 .*= (fdv + true) / sqrt(m)
         qrpiv = qr(x, Val(true))
         piv = qrpiv.p
+        fill!(v1, true)    # restore the contents of the first column
     end
 
     # preserve as much of the original column ordering as possible
-    piv = [sort!(piv[1:rank]); sort!(piv[rank+1:n])];
-    qrunp = qr(x[:, piv], Val(false));
-
-    QRPivoted(qrunp.factors, qrpiv.τ, piv)
+    sort!(view(piv, 1:rank))
+    (rank = rank, piv = piv)
 end

--- a/src/linalg/pivot.jl
+++ b/src/linalg/pivot.jl
@@ -1,54 +1,7 @@
 """
-    statscholesky(xtx::Symmetric{T}, tol::Real=-1) where {T<:AbstractFloat}
-Return a `CholeskyPivoted` object created from `xtx` where the pivoting scheme
-retains the original order unless singularity is detected.  Columns that are
-(computationally) linearly dependent on columns to their left are moved to the
-right hand side in a left circular shift.
-"""
-function statscholesky(xtx::Symmetric{T}, tol::Real = -1) where {T<:AbstractFloat}
-    n = size(xtx, 2)
-    chpiv = cholesky(xtx, Val(true), tol = T(tol), check = false)
-    chunp = cholesky(xtx, check = false);
-
-    piv = LinearAlgebra.BlasInt.(collect(1:n))
-    r = chpiv.rank
-
-    if r < n
-
-        k = chunp.info
-        if k > r
-            @warn """Fixed-effects matrix may be ill conditioned.
-                     Left-circular shift may fail."""
-        end
-
-        nleft = n
-        while nleft > r
-            # the 0 lowerbound is for MKL compatibility
-            # this arises when the unpivoted Cholesky succeeds but the pivoted
-            # Chokesky estimates less than full rank (see #367)
-            if 0 < k < nleft
-                piv = piv[[1:k-1; k+1:n; k]]
-                chunp = cholesky!(Symmetric(xtx[piv, piv]), check = false)
-            end
-            k = chunp.info
-            nleft -= 1
-        end
-
-        for j = (r+1):n   # an MKL <-> OpenBLAS difference
-            for i = (r+1):j
-                chunp.factors[i, j] = zero(T)
-            end
-        end
-
-    end
-
-    CholeskyPivoted(chunp.factors, chunp.uplo, piv, r, tol, chpiv.info)
-end
-
-"""
     statsqr(x::Matrix{T}, ranktol::Real=1e-8) where {T<:AbstractFloat}
-Return a `QRPivoted` object created from `x` where the pivoting scheme
-retains the original order unless singularity is detected.
+
+Return the numerical column rank and, for a rank-deficient X, a pivot vector
 """
 function statsqr(x::Matrix{T}; ranktol=1e-8) where {T<:AbstractFloat}
     n = size(x, 2)

--- a/src/linalg/pivot.jl
+++ b/src/linalg/pivot.jl
@@ -11,26 +11,29 @@ In the full-rank case the pivot vector is `collect(axes(x, 2))`.
 """
 function statsrank(x::AbstractMatrix{T}; ranktol=1e-8) where {T<:AbstractFloat}
     m, n = size(x)
+    piv = collect(axes(x, 2))
+
+    iszero(n) && return (rank = n, piv = piv)
 
     qrpiv = qr(x, Val(true))
     dvec = abs.(diag(qrpiv.R))
     fdv = first(dvec)
-    if (last(dvec) / fdv) > ranktol
-        return (rank = n, piv = collect(axes(x, 2)))
-    end
-    rank = searchsortedlast(dvec ./ fdv, ranktol, rev=true)
+    cmp = fdv * ranktol
+    (last(dvec) > cmp) && return (rank = n, piv = piv)
+
+    rank = searchsortedlast(dvec, cmp, rev=true)
     @assert rank < n
     piv = qrpiv.p
     v1 = first(eachcol(x))
     if all(isone, v1) && first(piv) ≠ 1
         # make sure the first column isn't moved by inflating v1
-        v1 .*= (fdv + true) / sqrt(m)
+        v1 .*= (fdv + one(fdv)) / sqrt(m)
         qrpiv = qr(x, Val(true))
         piv = qrpiv.p
         fill!(v1, one(T))    # restore the contents of the first column
     end
 
-    # preserve as much of the original column ordering as possible
-    sort!(view(piv, 1:rank)) # maintain the original column order for the linearly independent columns
+    # maintain original column order for the linearly independent columns
+    sort!(view(piv, 1:rank))
     (rank = rank, piv = piv)
 end

--- a/test/pivot.jl
+++ b/test/pivot.jl
@@ -47,3 +47,10 @@ end
     unpivoted = pivot[begin:r]
     @test unpivoted == sort(unpivoted)
 end
+
+@testset "zero columns in X" begin
+    X = Matrix{Float64}(undef, 100, 0)
+    r, pivot = statsrank(X)
+    @test iszero(r)
+    @test pivot == collect(axes(X, 2))
+end

--- a/test/pivot.jl
+++ b/test/pivot.jl
@@ -47,15 +47,3 @@ end
     unpivoted = st.p[begin:rank(st)]
     @test unpivoted == sort(unpivoted)
 end
-
-@testset "cholesky missing cells" begin
-    mm = modelmatrix(@formula(Y ~ 1 + G*H), simdat)
-    # when a cell is missing, the indicator for it is always zero
-    mm[:, 43] .= 0
-    XtX = xtx(mm)
-    ch = statscholesky(XtX)
-    perm = [1:42; 44:100; 43]
-    @test ch.rank == 99
-    @test ch.piv == perm
-    @test isapprox(xtx(ch.U), XtX[perm, perm], atol=0.00001)
-end

--- a/test/pivot.jl
+++ b/test/pivot.jl
@@ -1,6 +1,6 @@
 using LinearAlgebra, StableRNGs, StatsModels, Test
 
-import MixedModels: statsqr, statscholesky
+import MixedModels: statsrank
 
 xtx(X) = Symmetric(X'X, :U)  # creat the symmetric matrix X'X from X
 LinearAlgebra.rank(F::LinearAlgebra.QRPivoted; tol=1e-8) = searchsortedlast(abs.(diag(F.R)), tol, rev=true);
@@ -18,32 +18,32 @@ const simdat = (
 
 @testset "fullranknumeric" begin
     mm = modelmatrix(@formula(Y ~ 1 + U), simdat)
-    st = statsqr(mm)
-    @test st.p == 1:2
+    r, pivot = statsrank(mm)
+    @test pivot == 1:2
 end
 
 @testset "fullrankcategorical" begin
     mm = modelmatrix(@formula(Y ~ 1 + G*H), simdat)
-    st = statsqr(mm)
-    @test rank(st) == 100
-    @test st.p == 1:100
+    r, pivot = statsrank(mm)
+    @test r == 100
+    @test pivot == 1:100
 end
 
 @testset "dependentcolumn" begin
     mm = modelmatrix(@formula(Y ~ 1 + U + V + Z), simdat)
-    st = statsqr(mm)
+    r, pivot = statsrank(mm)
     perm = [1,2,4,3]
-    @test rank(st) == 3
-    @test st.p == perm
+    @test r == 3
+    @test pivot == perm
 end
 
 @testset "qr missing cells" begin
     mm = modelmatrix(@formula(Y ~ 1 + G*H), simdat)[5:end,:]
-    st = statsqr(mm)
-    @test rank(st) == 98
+    r, pivot = statsrank(mm)
+    @test r == 98
     # we no longer offer ordering guarantees besides preserving
     # relative order of linearly independent columns
     # and trying to keep the first column in the first position
-    unpivoted = st.p[begin:rank(st)]
+    unpivoted = pivot[begin:r]
     @test unpivoted == sort(unpivoted)
 end


### PR DESCRIPTION
- add `statsrank` to compute the rank and pivot vector for a model matrix using a pivoted QR decomposition
- modify tests, etc.
- remove `statsqr` and `statscholesky` functions