### PR TITLE
FORWARDPORT: shortestcovint for MixedModelBootstrap objects

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -15,26 +15,31 @@ jobs:
           ssh: ${{ secrets.DOCUMENTER_KEY }} # see https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#GitHub-Actions
           changelog: |
               ## {{ package }} {{ version }}
-              
+
               {% if previous_release %}
-              [NEWS file](https://github.com/JuliaStats/MixedModels.jl/blob/{{ version }}/NEWS.md). 
+              [NEWS file](https://github.com/JuliaStats/MixedModels.jl/blob/{{ version }}/NEWS.md).
               [Diff since {{ previous_release }}]({{ compare_url }})
               {% endif %}
-              
+
               {% if custom %}
               {{ custom }}
               {% endif %}
-              
+
+
+              *NB: Closed issues and pull requests are sorted temporally and so may
+              include backports to other versions or work in the development branch for
+              an upcoming breaking release. Please see the [NEWS file](https://github.com/JuliaStats/MixedModels.jl/blob/{{ version }}/NEWS.md)
+              for changes sorted by release.*
               {% if issues %}
               **Closed issues:**
               {% for issue in issues %}
               - {{ issue.title }} (#{{ issue.number }})
               {% endfor %}
               {% endif %}
-              
+
               {% if pulls %}
               **Merged pull requests:**
               {% for pull in pulls %}
               - {{ pull.title }} (#{{ pull.number }}) (@{{ pull.author.username }})
               {% endfor %}
-              {% endif %}            
+              {% endif %}

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@ MixedModels v4.0.0 Release Notes
 * Introduce an abstract type for collections of fits `MixedModelFitCollection`,
   and make `MixedModelBootstrap` a subtype of it. Accordingly, rename the `bstr`
   field to `fits`. [#465]
+* The response (dependent variable) is now stored internally as part of the
+  fixed-effects block. The `FeMat` and `FeTerm` types have changed correspondingly. [#464]
 * Replace internal `statscholesky` and `statsqr` functions for determining the
   rank of `X` by `statsrank`. [#479]
 
@@ -173,9 +175,11 @@ Package dependencies
 [#447]: https://github.com/JuliaStats/MixedModels.jl/issues/447
 [#449]: https://github.com/JuliaStats/MixedModels.jl/issues/449
 [#456]: https://github.com/JuliaStats/MixedModels.jl/issues/456
+[#464]: https://github.com/JuliaStats/MixedModels.jl/issues/464
 [#465]: https://github.com/JuliaStats/MixedModels.jl/issues/465
 [#469]: https://github.com/JuliaStats/MixedModels.jl/issues/469
 [#470]: https://github.com/JuliaStats/MixedModels.jl/issues/470
 [#474]: https://github.com/JuliaStats/MixedModels.jl/issues/474
+[#479]: https://github.com/JuliaStats/MixedModels.jl/issues/479
 [#480]: https://github.com/JuliaStats/MixedModels.jl/issues/480
 [#484]: https://github.com/JuliaStats/MixedModels.jl/issues/484

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ MixedModels v4.0.0 Release Notes
   and make `MixedModelBootstrap` a subtype of it. Accordingly, rename the `bstr`
   field to `fits`. [#465]
 * The response (dependent variable) is now stored internally as part of the
-  fixed-effects block. The `FeMat` and `FeTerm` types have changed correspondingly. [#464]
+  the renamed `FeMat` field, now called `Xymat` [#464]
 * Replace internal `statscholesky` and `statsqr` functions for determining the
   rank of `X` by `statsrank`. [#479]
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ MixedModels v4.0.0 Release Notes
 * Introduce an abstract type for collections of fits `MixedModelFitCollection`,
   and make `MixedModelBootstrap` a subtype of it. Accordingly, rename the `bstr`
   field to `fits`. [#465]
-* Replace internal `statscholesky` and `statsqr` functions for determining the 
+* Replace internal `statscholesky` and `statsqr` functions for determining the
   rank of `X` by `statsrank`. [#479]
 
 Run-time formula syntax
@@ -22,6 +22,10 @@ Run-time formula syntax
 * Methods for `Base./(::AbstractTerm, ::AbstractTerm)` are added, allowing
   nesting syntax to be used with `Term`s at run-time as well [#470]
 
+
+MixedModels v3.4.0 Release Notes
+========================
+* `shortestcovint` method for `MixedModelsBootstrap` [#484]
 
 MixedModels v3.3.0 Release Notes
 ========================
@@ -173,3 +177,5 @@ Package dependencies
 [#469]: https://github.com/JuliaStats/MixedModels.jl/issues/469
 [#470]: https://github.com/JuliaStats/MixedModels.jl/issues/470
 [#474]: https://github.com/JuliaStats/MixedModels.jl/issues/474
+[#480]: https://github.com/JuliaStats/MixedModels.jl/issues/480
+[#484]: https://github.com/JuliaStats/MixedModels.jl/issues/484

--- a/docs/src/bootstrap.md
+++ b/docs/src/bootstrap.md
@@ -94,6 +94,11 @@ We generate these for all random and fixed effects:
 combine(groupby(df, [:type, :group, :names]), :value => shortestcovint => :interval)
 ```
 
+We can also generate this directly from the original bootstrap object:
+```@example Main
+DataFrame(shortestcovint(samp))
+```
+
 A value of zero for the standard deviation of the random effects is an example of a *singular* covariance.
 It is easy to detect the singularity in the case of a scalar random-effects term.
 However, it is not as straightforward to detect singularity in vector-valued random-effects terms.
@@ -116,7 +121,7 @@ first(df2, 10)
 the singularity can be exhibited as a standard deviation of zero or as a correlation of $\pm1$.
 
 ```@example Main
-combine(groupby(df2, [:type, :group, :names]), :value => shortestcovint => :interval)
+DataFrame(shortestcovint(samp2))
 ```
 
 A histogram of the estimated correlations from the bootstrap sample has a spike at `+1`.

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -104,11 +104,7 @@ end
         contra = dataset(:contra)
         gm0 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli(), fast=true)
         bs = parametricbootstrap(StableRNG(42), 100, gm0)
-        bsci = combine(groupby(DataFrame(bs.β), :coefname),
-                       :β => shortestcovint => :ci)
-        bsci.lower = first.(bsci.ci)
-        bsci.upper = last.(bsci.ci)
-        select!(bsci, Not(:ci))
+        bsci = filter!(:type => ==("β"), DataFrame(shortestcovint(bs)))
         ciwidth = 2 .* stderror(gm0)
         waldci = DataFrame(coef=fixefnames(gm0),
                            lower=fixef(gm0) .- ciwidth,


### PR DESCRIPTION
This brings #484 to the 4.0-DEV series.

I have also updated the NEWS file for the Xy block changes.