### PR TITLE
update standard tests to include 1.6

### DIFF
--- a/.github/workflows/Tier1.yml
+++ b/.github/workflows/Tier1.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.4,1.5]
+        julia-version: [1.4, 1.6]
         julia-arch: [x64]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
     steps:

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
         with:
-          version: 1.6-nightly
+          version: 1.6
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Typical distribution forms are _Bernoulli_ for binary data or _Poisson_ for coun
 
 |OS|OS Version|Arch|Julia|Tier|
 |:-:|:-:|:-:|:-:|:-:|
-|Linux|Ubuntu 18.04|x64|v1.4, 1.5|1|
-|macOS|Catalina 10.15|x64|v1.4, 1.5|1|
-|Windows|Server 2019|x64|v1.4, 1.5 |1|
+|Linux|Ubuntu 18.04|x64|v1.4, 1.5, 1.6|1|
+|macOS|Catalina 10.15|x64|v1.4, 1.5, 1.6|1|
+|Windows|Server 2019|x64|v1.4, 1.5, 1.6|1|
 
 Upon release of the next Julia LTS, Tier 1 will become Tier 2 and Julia LTS will become Tier 1.
 


### PR DESCRIPTION
I've removed 1.5 from the tests because we're already doing a lot of testing and if things work on 1.4 and 1.6, they probably work on 1.5. 

As soon as 1.6 is officially declared LTS and 1.7 is released, then we can test on `[1.6, 1]` for Tier 1 and `[1.4]` for Tier 2 (or whatever the last version of Julia with all the linear algebra features we need is).