### PR TITLE
Deprecate `named` kwarg in 3.x branch

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v3.5.2 Release Notes
+========================
+* Explicitly deprecate non-functional `named` kwarg in `ranef` in favor of `raneftables` [#507].
+
 MixedModels v3.5.1 Release Notes
 ========================
 * Fix MIME show methods for models with random-effects not corresponding to a fixed effect [#501].

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "3.5.1"
+version = "3.5.2"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -689,14 +689,16 @@ end
 ranef!(v::Vector, m::LinearMixedModel, uscale::Bool) = ranef!(v, m, fixef(m), uscale)
 
 """
-    ranef(m::LinearMixedModel; uscale=false, named=false)
+    ranef(m::LinearMixedModel; uscale=false)
 
 Return, as a `Vector{Matrix{T}}`, the conditional modes of the random effects in model `m`.
 
 If `uscale` is `true` the random effects are on the spherical (i.e. `u`) scale, otherwise on
 the original scale.
+
+For a named variant, see [`@raneftables`](@ref).
 """
-function ranef(m::LinearMixedModel{T}; uscale = false, named = false) where {T}
+function ranef(m::LinearMixedModel{T}; uscale = false) where {T}
     reterms = m.reterms
     v = [Matrix{T}(undef, size(t.z, 1), nlevs(t)) for t in reterms]
     ranef!(v, m, uscale)

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -689,7 +689,7 @@ end
 ranef!(v::Vector, m::LinearMixedModel, uscale::Bool) = ranef!(v, m, fixef(m), uscale)
 
 """
-    ranef(m::LinearMixedModel; uscale=false)
+    ranef(m::MixedModel; uscale=false)
 
 Return, as a `Vector{Matrix{T}}`, the conditional modes of the random effects in model `m`.
 
@@ -698,7 +698,10 @@ the original scale.
 
 For a named variant, see [`@raneftables`](@ref).
 """
-function ranef(m::LinearMixedModel{T}; uscale = false) where {T}
+function ranef(m::LinearMixedModel{T}; uscale = false, named=nothing) where {T}
+    if named !== nothing
+        Base.depwarn("the `named` keyword argument is deprecated; it has no effect. Use `raneftables` instead.", :ranef)
+    end
     reterms = m.reterms
     v = [Matrix{T}(undef, size(t.z, 1), nlevs(t)) for t in reterms]
     ranef!(v, m, uscale)


### PR DESCRIPTION
cf. #469 

Closes #499 