### PR TITLE
Add full API listing

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,7 @@ makedocs(
         "bootstrap.md",
         "rankdeficiency.md",
         "mime.md",
+        "api.md",
         # "SimpleLMM.md",
         # "MultipleTerms.md",
         # "SingularCovariance.md",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,28 @@
+# API
+
+In addition to its own functionality, MixedModels.jl also implements extensive support for the `StatsBase.StatisticalModel` and `StatsBase.RegressionModel` API.
+
+## Types
+
+```@autodocs
+Modules = [MixedModels]
+Order   = [:type]
+```
+
+## Exported Functions
+```@autodocs
+Modules = [MixedModels]
+Private = false
+Order   = [:function]
+```
+
+## Non-Exported Functions
+
+Note that unless discussed elsewhere in the online documentation, non-exported functions should be considered implementation details.
+
+```@autodocs
+Modules = [MixedModels]
+Public  = false
+Order   = [:function]
+Filter = f -> !startswith(string(f), "_")
+```

--- a/src/gausshermite.jl
+++ b/src/gausshermite.jl
@@ -29,7 +29,7 @@ sum(@. abs2(σ*gn5.z + μ)*gn5.w) # E[X^2] where X ∼ N(μ, σ)
 For evaluation of the log-likelihood of a GLMM the integral to evaluate for each level of
 the grouping factor is approximately Gaussian shaped.
 """
-GaussHermiteQuadrature
+
 """
     GaussHermiteNormalized{K}
 

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -79,8 +79,8 @@ Return the deviance of `m` evaluated by the Laplace approximation (`nAGQ=1`)
 or `nAGQ`-point adaptive Gauss-Hermite quadrature.
 
 If the distribution `D` does not have a scale parameter the Laplace approximation
-is the squared length of the conditional modes, `u`, plus the determinant
-of `Λ'Z'WZΛ + I`, plus the sum of the squared deviance residuals.
+is the squared length of the conditional modes, ``u``, plus the determinant
+of ``Λ'Z'WZΛ + I``, plus the sum of the squared deviance residuals.
 """
 function StatsBase.deviance(m::GeneralizedLinearMixedModel{T}, nAGQ = 1) where {T}
     nAGQ == 1 && return T(sum(m.resp.devresid) + logdet(m) + sum(u -> sum(abs2, u), m.u))
@@ -134,7 +134,7 @@ end
     deviance!(m::GeneralizedLinearMixedModel, nAGQ=1)
 
 Update `m.η`, `m.μ`, etc., install the working response and working weights in
-`m.LMM`, update `m.LMM.A` and `m.LMM.R`, then evaluate the [`deviance`](@ref).
+`m.LMM`, update `m.LMM.A` and `m.LMM.R`, then evaluate the [`deviance`](@ref StatsBase.deviance).
 """
 function deviance!(m::GeneralizedLinearMixedModel, nAGQ = 1)
     updateη!(m)

--- a/src/grouping.jl
+++ b/src/grouping.jl
@@ -3,10 +3,10 @@
     struct Grouping <: StatsModels.AbstractContrasts end
 
 A placeholder type to indicate that a categorical variable is only used for
-grouping and not for contrasts.  When creating a [`CategoricalTerm`](@ref), this
+grouping and not for contrasts.  When creating a `CategoricalTerm`, this
 skips constructing the contrasts matrix which makes it robust to large numbers
 of levels, while still holding onto the vector of levels and constructing the
-level-to-index mapping (`invindex` field of the [`ContrastsMatrix`](@ref).).
+level-to-index mapping (`invindex` field of the `ContrastsMatrix`.).
 
 Note that calling `modelcols` on a `CategoricalTerm{Grouping}` is an error.
 

--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -59,7 +59,7 @@ Likeihood ratio test applied to a set of nested models.
 
 !!! note
     The nesting of the models is not checked.  It is incumbent on the user
-    to check this. This differs from [`StatsModels.lrtest`](@ref) as nesting in
+    to check this. This differs from `StatsModels.lrtest` as nesting in
     mixed models, especially in the random effects specification, may be non obvious.
 
 !!! note
@@ -68,7 +68,7 @@ Likeihood ratio test applied to a set of nested models.
     fully saturated model. This is in line with the computation of the deviance for mixed
     models.
 
-This functionality may be deprecated in the future in favor of [`StatsModels.lrtest`](@ref).
+This functionality may be deprecated in the future in favor of `StatsModels.lrtest`.
 """
 function likelihoodratiotest(m::MixedModel...)
     _iscomparable(m...) || throw(


### PR DESCRIPTION
> @palday I think this is ready to go if the CI checks out.  Can you take a look at it and pull the trigger if you agree?  I can make the modifications to #514 after this lands.  It would probably be a good idea to make a separate section of the docs to describe methods for generics declared in `StatsBase`.  I can start on that if you agree.

_Originally posted by @dmbates in https://github.com/JuliaStats/MixedModels.jl/issues/520#issuecomment-841401385_

Here's an example of using `@autodoc` to generate the full API listing. It highlights that we have a few truly private functions (like `cpad`) that we should probably mark as such. 

I also want to figure out why `deviance` is leading to a Documenter warning for the autodocs...