### PR TITLE
LinearAlgebra.mul! instead of unscaledre!

### DIFF
--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -718,14 +718,14 @@ end
 
 Update the linear predictor, `m.η`, from the offset and the `B`-scale random effects.
 """
-function updateη!(m::GeneralizedLinearMixedModel)
+function updateη!(m::GeneralizedLinearMixedModel{T}) where {T}
     η = m.η
     b = m.b
     u = m.u
     reterms = m.LMM.reterms
     mul!(η, modelmatrix(m), m.β)
     for i in eachindex(b)
-        unscaledre!(η, reterms[i], mul!(b[i], reterms[i].λ, u[i]))
+        mul!(η, reterms[i], vec(mul!(b[i], reterms[i].λ, u[i])), one(T), one(T))
     end
     GLM.updateμ!(m.resp, η)
     m

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -448,7 +448,7 @@ function fitted!(v::AbstractArray{T}, m::LinearMixedModel{T}) where {T}
     Xtrm = m.feterm
     vv = mul!(vec(v), Xtrm.x, fixef!(similar(Xtrm.piv, T), m))
     for (rt, bb) in zip(m.reterms, ranef(m))
-        unscaledre!(vv, rt, bb)
+        mul!(vv, rt, bb, one(T), one(T))
     end
     v
 end

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -42,7 +42,7 @@ function StatsBase.predict!(y::AbstractVector{<:Union{T, Missing}}, m::LinearMix
     # because we're using ranef(), this actually
     # adds the *scaled* random effects
     for (rt, bb) in zip(m.reterms, ranef(m))
-        unscaledre!(y, rt, bb)
+        mul!(y, rt, vec(bb), one(T), one(T))
     end
 
     y
@@ -61,7 +61,7 @@ function StatsBase.predict!(y::AbstractVector{<:Union{T, Missing}}, m::Generaliz
         # because we're using ranef(), this actually
         # adds the *scaled* random effects
         for (rt, bb) in zip(m.reterms, ranef(m))
-            unscaledre!(y, rt, bb)
+            mul!(y, rt, bb, one(T), one(T))
         end
     end
 
@@ -260,7 +260,7 @@ function StatsBase.predict(m::LinearMixedModel{T}, newdata::Tables.ColumnTable;
     end
 
     for (rt, bb) in zip(newre, blups)
-        unscaledre!(y, rt, bb)
+        mul!(y, rt, bb, one(T), one(T))
     end
 
     y


### PR DESCRIPTION
- `unscaledre!` had methods that didn't really correspond to simulating and incorporating unscaled random effects.  
- These methods are rewritten here as `LinearAlgebra.mul!` methods.