### PR TITLE
Add explanation for a broken test.  Correct a typo

### DIFF
--- a/test/matrixterm.jl
+++ b/test/matrixterm.jl
@@ -46,11 +46,12 @@ end
         @test isapprox(m1.θ, m.θ, rtol = 1.0e-5)
     end
 
-    @testset "rank defiency in sparse FeTerm" begin
+    @testset "rank deficiency in sparse FeTerm" begin
         trm = MixedModels.FeTerm(SparseMatrixCSC(hcat(ones(30), 
                                                      repeat(0:9, outer = 3), 
                                                      2repeat(0:9, outer = 3))), 
                                 ["(Intercept)", "U", "V"])
+        # at present there is no attempt to evaluate the rank of a SparseMatrixCSC
         piv = trm.piv
         ipiv = invperm(piv)
         @test_broken rank(trm) == 2


### PR DESCRIPTION
I kept forgetting the reason that one of our tests is still broken and eventually decided to add a comment to remind myself.