### PR TITLE
σs for Diagonal ReMat and test

### DIFF
--- a/src/remat.jl
+++ b/src/remat.jl
@@ -522,10 +522,16 @@ function σs(A::ReMat{T,1}, sc::T) where {T}
     NamedTuple{(Symbol(only(A.cnames)),)}(sc*abs(only(A.λ.data)),)
 end
 
-function σs(A::ReMat{T}, sc::T) where {T}
-    λ = A.λ.data
-    NamedTuple{(Symbol.(A.cnames)...,)}(ntuple(i -> sc*norm(view(λ,i,1:i)), size(λ, 1)))
+function _σs(λ::LowerTriangular{T}, sc::T, cnames) where {T}
+    λ = λ.data
+    NamedTuple{(Symbol.(cnames)...,)}(ntuple(i -> sc*norm(view(λ,i,1:i)), size(λ, 1)))
 end
+
+function _σs(λ::Diagonal{T}, sc::T, cnames) where {T}
+    NamedTuple{(Symbol.(cnames)...,)}(((sc .* λ.diag)...,))
+end
+
+σs(A::ReMat{T}, sc::T) where {T} = _σs(A.λ, sc, A.cnames)
 
 function σρs(A::ReMat{T,1}, sc::T) where {T}
     NamedTuple{(:σ,:ρ)}(

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -355,6 +355,9 @@ end
     @test size(fmnc) == (180,2,36,1)
     @test fmnc.optsum.initial == ones(2)
     @test lowerbd(fmnc) == zeros(2)
+    sigmas = fmnc.σs
+    @test length(only(sigmas)) == 2
+    @test first(only(sigmas)) ≈ 24.171449484676224 atol=1e-4
 
     @testset "zerocorr PCA" begin
         @test length(fmnc.rePCA) == 1


### PR DESCRIPTION
- Add internal methods for σs for `ReMat{T,S}` so the case of a Diagonal λ is handled properly
- Add a test
- Closes #531 
