### PR TITLE
Rename allequal to isconstant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@ Run-time formula syntax
 MixedModels v3.9.0 Release Notes
 ========================
 * Add support for `StatsModels.formula` [#536]
+* Internal method `allequal` renamed to `isconstant` [#537]
 
 MixedModels v3.8.0 Release Notes
 ========================
@@ -255,3 +256,4 @@ Package dependencies
 [#523]: https://github.com/JuliaStats/MixedModels.jl/issues/523
 [#524]: https://github.com/JuliaStats/MixedModels.jl/issues/524
 [#536]: https://github.com/JuliaStats/MixedModels.jl/issues/536
+[#537]: https://github.com/JuliaStats/MixedModels.jl/issues/537

--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -204,15 +204,15 @@ end
 Base.show(io::IO, lrt::LikelihoodRatioTest) = Base.show(io, MIME"text/plain"(), lrt)
 
 function _iscomparable(m::LinearMixedModel...)
-    allequal(getproperty.(getproperty.(m,:optsum),:REML)) ||
+    isconstant(getproperty.(getproperty.(m,:optsum),:REML)) ||
         throw(ArgumentError("Models must all be fit with the same objective (i.e. all ML or all REML)"))
 
     if any(getproperty.(getproperty.(m,:optsum),:REML))
-        allequal(coefnames.(m))  ||
+        isconstant(coefnames.(m))  ||
                 throw(ArgumentError("Likelihood-ratio tests for REML-fitted models are only valid when the fixed-effects specifications are identical"))
     end
 
-    allequal(nobs.(m)) ||
+    isconstant(nobs.(m)) ||
         throw(ArgumentError("Models must have the same number of observations"))
 
     true
@@ -226,10 +226,10 @@ function _iscomparable(m::GeneralizedLinearMixedModel...)
     _samefamily(m...) ||
         throw(ArgumentError("Models must be fit to the same distribution"))
 
-    allequal(string.(Link.(m))) ||
+    isconstant(string.(Link.(m))) ||
         throw(ArgumentError("Models must have the same link function"))
 
-    allequal(nobs.(m)) ||
+    isconstant(nobs.(m)) ||
         throw(ArgumentError("Models must have the same number of observations"))
 
     return true

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,24 +1,17 @@
 """
-    allequal(x::Array)
-    allequal(x::Tuple)
-Return the equality of all elements of the array
+    isconstant(x::Array)
+    isconstant(x::Tuple)
+
+Are all elements of the iterator the same?  That is, is it constant?
 """
-function allequal(x::Array; comparison=isequal)::Bool
+function isconstant(x; comparison=isequal)::Bool
     # the ref is necessary in case the elements of x are themselves arrays
-    all(comparison.(x,  Ref(first(x))))
+    isempty(x) || all(ismissing, x) || coalesce(all(comparison.(x,  Ref(first(x)))), false)
 end
 
-allequal(x::Vector{Bool})::Bool = !any(x) || all(x)
+isconstant(x::Vector{Bool})::Bool = !any(x) || all(x)
 
-allequal(x::NTuple{N,Bool}) where {N} = !any(x) || all(x)
-
-function allequal(x::Tuple; comparison=isequal)::Bool
-    all(comparison.(x,  Ref(first(x))))
-end
-
-function allequal(x...; comparison=isequal)::Bool
-    all(comparison.(x,  Ref(first(x))))
-end
+isconstant(x...; comparison=isequal) = isconstant(x; comparison=comparison)
 
 """
     average(a::T, b::T) where {T<:AbstractFloat}

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -30,9 +30,9 @@ end
 	@test isconstant([false, false, false])
 	@test isconstant(ones(3))
 	@test isconstant(1, 1, 1)
-						# equality of arrays with broadcasting
+	# equality of arrays with broadcasting
 	@test isconstant(["(Intercept)", "days"], ["(Intercept)", "days"])
-						# arrays or tuples with missing values
+	# arrays or tuples with missing values
 	@test !isconstant([missing, 1])
 	@test isconstant(Int[])
 	@test isconstant(Union{Int,Missing}[missing, missing, missing])

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -4,7 +4,7 @@ using StableRNGs
 using SparseArrays
 using Test
 
-using MixedModels: allequal, average, densify, dataset
+using MixedModels: isconstant, average, densify, dataset
 using StatsModels: FormulaTerm
 
 include("modelcache.jl")
@@ -20,19 +20,22 @@ end
 	@test densify(Diagonal(rsparsev)) == Diagonal(Vector(rsparsev))
 end
 
-@testset "allequal" begin
-	@test allequal((true, true, true))
-	@test allequal([true, true, true])
-	@test !allequal((true, false, true))
-	@test !allequal([true, false, true])
-	@test !allequal(collect(1:4))
-	@test allequal((false, false, false))
-	@test allequal([false, false, false])
-	@test allequal(ones(3))
-	@test allequal(1, 1, 1)
-
-	# equality of arrays with broadcasting
-	@test allequal(["(Intercept)", "days"], ["(Intercept)", "days"])
+@testset "isconstant" begin
+	@test isconstant((true, true, true))
+	@test isconstant([true, true, true])
+	@test !isconstant((true, false, true))
+	@test !isconstant([true, false, true])
+	@test !isconstant(collect(1:4))
+	@test isconstant((false, false, false))
+	@test isconstant([false, false, false])
+	@test isconstant(ones(3))
+	@test isconstant(1, 1, 1)
+						# equality of arrays with broadcasting
+	@test isconstant(["(Intercept)", "days"], ["(Intercept)", "days"])
+						# arrays or tuples with missing values
+	@test !isconstant([missing, 1])
+	@test isconstant(Int[])
+	@test isconstant(Union{Int,Missing}[missing, missing, missing])
 end
 
 @testset "threaded_replicate" begin


### PR DESCRIPTION
- rename `allequal` to `isconstant`
- extend the base method to handle empty collections and iterators that include missing values
- add tests