### PR TITLE
Added opt. fname argument to sparseL and condVar

### DIFF
--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -319,7 +319,7 @@ function condVar(m::LinearMixedModel{T}, fname) where {T}
     Lblk = LowerTriangular(densify(sparseL(m; fname=fname)))
     blk = findfirst(isequal(fname), fnames(m))
     λt = Array(m.λ[blk]') .* sdest(m)
-    vsz =  size(λt, 2)
+    vsz = size(λt, 2)
     ℓ = length(m.reterms[blk].levels)
     val = Array{T}(undef, (vsz, vsz, ℓ))
     scratch = Matrix{T}(undef, (size(Lblk, 1), vsz))
@@ -329,9 +329,9 @@ function condVar(m::LinearMixedModel{T}, fname) where {T}
         ldiv!(Lblk, scratch)
         mul!(view(val, :, :, b), scratch', scratch)
     end
-    val
+    return val
 end
-    
+
 function _cvtbl(arr::Array{T,3}, trm) where {T}
     return merge(
         NamedTuple{(fname(trm),)}((trm.levels,)),
@@ -1005,9 +1005,7 @@ are to be included.
  to `fname` are dropped. The default is the first, i.e., leftmost block and hence all blocks.
 """
 function sparseL(
-    m::LinearMixedModel{T};
-    fname::Symbol=first(fnames(m)),
-    full::Bool=false,
+    m::LinearMixedModel{T}; fname::Symbol=first(fnames(m)), full::Bool=false
 ) where {T}
     L, reterms = m.L, m.reterms
     sblk = findfirst(isequal(fname), fnames(m))

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -1001,8 +1001,8 @@ Return the lower Cholesky factor `L` as a `SparseMatrix{T,Int32}`.
 `full` indicates whether the parts of `L` associated with the fixed-effects and response
 are to be included.
 
-When `fname` is the name of a grouping factor the blocks to the left of that block are
-dropped.
+`fname` specifies the first grouping factor to include. Blocks to the left of the block corresponding
+ to `fname` are dropped. The default is the first, i.e., leftmost block and hence all blocks.
 """
 function sparseL(
     m::LinearMixedModel{T};

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -176,6 +176,8 @@ end
     @test first(first(cv)) ≈ 0.07331320237988301 rtol=1.e-4
     @test last(last(cv)) ≈ 0.04051547211287544 rtol=1.e-4
 
+    cv2 = condVar(fm, :sample)
+    @test cv2 ≈ last(cv)
     rfu = ranef(fm, uscale=true)
     @test length(rfu) == 2
     @test first(first(rfu)) ≈ 0.523162392717432 rtol=1.e-4


### PR DESCRIPTION
- `sparseL` gains an optional `fname` argument.  When a grouping factor name is given for this argument the return value consists of the lower-right triangle starting at that the rows and columns for that factor.
- `condVar` gains a method with a second argument `fname`.  When given the conditional variance array for that factor only is returned.
- the default `condVar` now just iterates over the grouping factor names.  ~(The old code is retained for comparison but will never be executed - it should be removed after review of this PR.)~
- the main use of `condVar` is in `MixedModelsMakie.caterpillar` which can now be simplified somewhat.
- this should provide considerable time savings for models like those fit by @kliegl to the FFGK21 dataset when only the caterpillar plot for the Schools is desired.  This still needs to be checked out.
- Needs specific tests for the newly introduced methods. 