### PR TITLE
add `fitlog`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,10 @@
 MixedModels v4.1.0 Release Notes
 ========================
 * Add support for specifying a fixed value of `σ`, the residual standard deviation,
-  in `LinearMixedModel`. `fit` takes a keyword-argument `σ`. For models constructed
-  separately, `σ` can be specified by setting `optsum.sigma`. [#551]
-  struct. [#551]
-
-
+  in `LinearMixedModel`. `fit` takes a keyword-argument `σ`. `fit!` does not expose `σ`,
+  but `σ` can be changed after model construction by setting `optsum.sigma`. [#551]
+* Add support for logging the non-linear optimizer's steps via a `fitlog`
+  keyword-argument for `fit` and `fit!`. [#552]
 
 MixedModels v4.0.0 Release Notes
 ========================
@@ -275,3 +274,4 @@ Package dependencies
 [#537]: https://github.com/JuliaStats/MixedModels.jl/issues/537
 [#539]: https://github.com/JuliaStats/MixedModels.jl/issues/539
 [#551]: https://github.com/JuliaStats/MixedModels.jl/issues/551
+[#552]: https://github.com/JuliaStats/MixedModels.jl/issues/552

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,11 @@ MixedModels v4.1.0 Release Notes
 * Add support for specifying a fixed value of `σ`, the residual standard deviation,
   in `LinearMixedModel`. `fit` takes a keyword-argument `σ`. `fit!` does not expose `σ`,
   but `σ` can be changed after model construction by setting `optsum.sigma`. [#551]
-* Add support for logging the non-linear optimizer's steps via a `fitlog`
-  keyword-argument for `fit` and `fit!`. [#552]
+* Add support for logging the non-linear optimizer's steps via a `thin`
+  keyword-argument for `fit` and `fit!`. The default behavior is 'maximal' thinning,
+  such that only the initial and final values are stored. `OptSummary` has a new field
+  `fitlog` that contains the aforementioned log as a  vector of tuples of parameter and
+  objective values.[#552]
 
 MixedModels v4.0.0 Release Notes
 ========================

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.0.0"
+version = "4.1.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -331,13 +331,14 @@ function fit!(
             xmin_[i] = zero(T)
         end
     end
+    !isnothing(fitlog) && (loglength = length(fitlog))
     if xmin ≠ xmin_
         if (zeroobj = obj(xmin_, T[])) ≤ (fmin + 1.e-5)
             fmin = zeroobj
             copyto!(xmin, xmin_)
-        else
-            # remove unused zero'ing step
-            !isnothing(fitlog) && pop!(fitlog)
+        elseif !isnothing(fitlog) && (length(fitlog) > loglength)
+            # remove unused extra log entry
+            pop!(fitlog)
         end
     end
     ## ensure that the parameter values saved in m are xmin

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -335,6 +335,9 @@ function fit!(
         if (zeroobj = obj(xmin_, T[])) ≤ (fmin + 1.e-5)
             fmin = zeroobj
             copyto!(xmin, xmin_)
+        else
+            # remove unused zero'ing step
+            pop!(fitlog)
         end
     end
     ## ensure that the parameter values saved in m are xmin

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -174,7 +174,7 @@ function fit(
     fast::Bool=false,
     nAGQ::Integer=1,
     progress::Bool=true,
-    fitlog::Union{Nothing, AbstractVector}=nothing,
+    fitlog::Union{Nothing,AbstractVector}=nothing,
     thin::Int=1,
 )
     return fit(
@@ -191,7 +191,7 @@ function fit(
         nAGQ,
         progress,
         fitlog,
-        thin
+        thin,
     )
 end
 
@@ -208,7 +208,7 @@ function fit(
     fast::Bool=false,
     nAGQ::Integer=1,
     progress::Bool=true,
-    fitlog::Union{Nothing, AbstractVector}=nothing,
+    fitlog::Union{Nothing,AbstractVector}=nothing,
     thin::Int=1,
 )
     return fit!(
@@ -238,11 +238,24 @@ function fit(
     fast::Bool=false,
     nAGQ::Integer=1,
     progress::Bool=true,
-    fitlog::Union{Nothing, AbstractVector}=nothing,
+    fitlog::Union{Nothing,AbstractVector}=nothing,
     thin::Int=1,
 )
     return fit(
-        GeneralizedLinearMixedModel, f, tbl, d, l; wts, contrasts, offset, verbose, fast, nAGQ, progress, fitlog, thin
+        GeneralizedLinearMixedModel,
+        f,
+        tbl,
+        d,
+        l;
+        wts,
+        contrasts,
+        offset,
+        verbose,
+        fast,
+        nAGQ,
+        progress,
+        fitlog,
+        thin,
     )
 end
 
@@ -276,7 +289,7 @@ function fit!(
     fast::Bool=false,
     nAGQ::Integer=1,
     progress::Bool=true,
-    fitlog::Union{Nothing, AbstractVector}=nothing,
+    fitlog::Union{Nothing,AbstractVector}=nothing,
     thin::Int=1,
 ) where {T}
     β = m.β

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -337,7 +337,7 @@ function fit!(
             copyto!(xmin, xmin_)
         else
             # remove unused zero'ing step
-            pop!(fitlog)
+            !isnothing(fitlog) && pop!(fitlog)
         end
     end
     ## ensure that the parameter values saved in m are xmin

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -307,21 +307,24 @@ function fit!(
     end
     setpar! = fast ? setθ! : setβθ!
     prog = ProgressUnknown("Minimizing"; showspeed=true)
-    !isnothing(fitlog) && empty!(fitlog)
-    iter = 1
+    # start from zero for the initial call to obj before optimization
+    iter = 0
     function obj(x, g)
         isempty(g) || throw(ArgumentError("g should be empty for this objective"))
         val = deviance(pirls!(setpar!(m, x), fast, verbose), nAGQ)
         !isnothing(fitlog) && iszero(rem(iter, thin)) && push!(fitlog, (copy(x), val))
-        iter += 1
         verbose && println(round(val; digits=5), " ", x)
         progress && ProgressMeter.next!(prog; showvalues=[(:objective, val)])
+        iter += 1
         return val
     end
     opt = Opt(optsum)
     NLopt.min_objective!(opt, obj)
     optsum.finitial = obj(optsum.initial, T[])
-    !isnothing(fitlog) && push!(fitlog, (copy(optsum.initial), optsum.finitial))
+    if !isnothing(fitlog)
+        empty!(fitlog)
+        push!(fitlog, (copy(optsum.initial), optsum.finitial))
+    end
     fmin, xmin, ret = NLopt.optimize(opt, copyto!(optsum.final, optsum.initial))
     ProgressMeter.finish!(prog)
     ## check if very small parameter values bounded below by zero can be set to zero

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -473,13 +473,14 @@ function fit!(
             xmin_[i] = zero(T)
         end
     end
-    if xmin_ ≠ xmin
+    !isnothing(fitlog) && (loglength = length(fitlog))
+    if xmin ≠ xmin_
         if (zeroobj = obj(xmin_, T[])) ≤ (fmin + 1.e-5)
             fmin = zeroobj
             copyto!(xmin, xmin_)
-        else
-            # remove unused zero'ing step
-            !isnothing(fitlog) && pop!(fitlog)
+        elseif !isnothing(fitlog) && (length(fitlog) > loglength)
+            # remove unused extra log entry
+            pop!(fitlog)
         end
     end
     ## ensure that the parameter values saved in m are xmin

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -418,9 +418,6 @@ Optimize the objective of a `LinearMixedModel`.  When `progress` is `true` a
 `ProgressMeter.ProgressUnknown` display is shown during the optimization of the
 objective, if the optimization takes more than one second or so.
 
-Specifying `σ` will update the corresponding `optsum.sigma` field and constrain
-the residual standard deviation accordingly.
-
 If `fitlog` is specified, then tuple a `(θ, objective)` at every `thin`th
 iteration  is recorded in `fitlog`.
 
@@ -438,7 +435,6 @@ function fit!(m::LinearMixedModel{T}; progress::Bool=true, REML::Bool=false,
     end
     opt = Opt(optsum)
     optsum.REML = REML
-    optsum.sigma = isnothing(σ) ? σ : T(σ)
     prog = ProgressUnknown("Minimizing"; showspeed=true)
     !isnothing(fitlog) && empty!(fitlog)
     iter = 1

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -894,7 +894,7 @@ function restoreoptsum!(m::LinearMixedModel{T}, io::IO) where {T}
         # compat with fits saved before fitlog
         [(ops.initial, ops.finitial, ops.final, ops.fmin)]
     else
-        [(convert(Vector{T}, first(entry)), T(last(entry))) for entry in fitlog ]
+        [(convert(Vector{T}, first(entry)), T(last(entry))) for entry in fitlog]
     end
     return m
 end

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -477,6 +477,9 @@ function fit!(
         if (zeroobj = obj(xmin_, T[])) ≤ (fmin + 1.e-5)
             fmin = zeroobj
             copyto!(xmin, xmin_)
+        else
+            # remove unused zero'ing step
+            pop!(fitlog)
         end
     end
     ## ensure that the parameter values saved in m are xmin

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -479,7 +479,7 @@ function fit!(
             copyto!(xmin, xmin_)
         else
             # remove unused zero'ing step
-            pop!(fitlog)
+            !isnothing(fitlog) && pop!(fitlog)
         end
     end
     ## ensure that the parameter values saved in m are xmin

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -187,7 +187,16 @@ function fit(
     thin=1,
 )
     return fit(
-        LinearMixedModel, f, Tables.columntable(tbl); wts, contrasts, progress, REML, σ, fitlog, thin
+        LinearMixedModel,
+        f,
+        Tables.columntable(tbl);
+        wts,
+        contrasts,
+        progress,
+        REML,
+        σ,
+        fitlog,
+        thin,
     )
 end
 
@@ -425,9 +434,14 @@ iteration  is recorded in `fitlog`.
     `fitlog` is emptied at the start of fitting and subsequently further
     modified to keep a log of the fitting process.
 """
-function fit!(m::LinearMixedModel{T}; progress::Bool=true, REML::Bool=false,
-              σ::Union{Real, Nothing}=nothing, fitlog::Union{AbstractVector, Nothing}=nothing,
-              thin::Int=1) where {T}
+function fit!(
+    m::LinearMixedModel{T};
+    progress::Bool=true,
+    REML::Bool=false,
+    σ::Union{Real,Nothing}=nothing,
+    fitlog::Union{AbstractVector,Nothing}=nothing,
+    thin::Int=1,
+) where {T}
     optsum = m.optsum
     # this doesn't matter for LMM, but it does for GLMM, so let's be consistent
     if optsum.feval > 0

--- a/src/optsummary.jl
+++ b/src/optsummary.jl
@@ -25,6 +25,11 @@ Summary of an `NLopt` optimization
 * `fitlog`: A vector of tuples of parameter and objectives values from steps in the optimization
 
 The latter four fields are MixedModels functionality and not related directly to the `NLopt` package or algorithms.
+
+!!! note
+    The internal storage of the parameter values within `fitlog` may change in
+    the future to use a different subtype of `AbstractVector` (e.g., `StaticArrays.SVector`)
+    for each snapshot without being considered a breaking change.
 """
 mutable struct OptSummary{T<:AbstractFloat}
     initial::Vector{T}

--- a/src/optsummary.jl
+++ b/src/optsummary.jl
@@ -4,8 +4,8 @@
 Summary of an `NLopt` optimization
 
 # Fields
-
 * `initial`: a copy of the initial parameter values in the optimization
+* `finitial`: the initial value of the objective
 * `lowerbd`: lower bounds on the parameter values
 * `ftol_rel`: as in NLopt
 * `ftol_abs`: as in NLopt
@@ -22,8 +22,9 @@ Summary of an `NLopt` optimization
 * `nAGQ`: number of adaptive Gauss-Hermite quadrature points in deviance evaluation for GLMMs
 * `REML`: use the REML criterion for LMM fits
 * `sigma`: a priori value for the residual standard deviation for LMM
+* `fitlog`: A vector of tuples of parameter and objectives values from steps in the optimization
 
-The latter three fields are model characteristics and not related directly to the `NLopt` package or algorithms.
+The latter four fields are MixedModels functionality and not related directly to the `NLopt` package or algorithms.
 """
 mutable struct OptSummary{T<:AbstractFloat}
     initial::Vector{T}
@@ -36,15 +37,17 @@ mutable struct OptSummary{T<:AbstractFloat}
     initial_step::Vector{T}
     maxfeval::Int
     maxtime::T
+    feval::Int
     final::Vector{T}
     fmin::T
-    feval::Int
     optimizer::Symbol
     returnvalue::Symbol
     nAGQ::Integer           # don't really belong here but I needed a place to store them
     REML::Bool
     sigma::Union{T,Nothing}
+    fitlog::Vector{Tuple{Vector{T}, T}} # not SVector because we would need to parameterize on size (which breaks GLMM)
 end
+
 function OptSummary(
     initial::Vector{T},
     lowerbd::Vector{T},
@@ -52,10 +55,13 @@ function OptSummary(
     ftol_rel::T=zero(T),
     ftol_abs::T=zero(T),
     xtol_rel::T=zero(T),
+    xtol_abs::Vector{T}=zero(initial) .+ 1e-10,
     initial_step::Vector{T}=T[],
     maxfeval=-1,
     maxtime=T(-1),
 ) where {T<:AbstractFloat}
+    fitlog = [(initial, T(Inf))]
+
     return OptSummary(
         initial,
         lowerbd,
@@ -63,20 +69,51 @@ function OptSummary(
         ftol_rel,
         ftol_abs,
         xtol_rel,
-        zero(initial),
+        xtol_abs,
         initial_step,
         maxfeval,
         maxtime,
+        -1,
         copy(initial),
         T(Inf),
-        -1,
         optimizer,
         :FAILURE,
         1,
         false,
         nothing,
+        fitlog,
     )
 end
+
+# function Base.getproperty(opt::OptSummary, s::Symbol)
+#     if s == :fmin
+#         last(last(opt.fitlog))
+#     elseif s == :finitial
+#         last(first(opt.fitlog))
+#     elseif s == :final
+#         first(last(opt.fitlog))
+#     elseif s == :initial
+#         first(first(opt.fitlog))
+#     else
+#         getfield(opt, s)
+#     end
+# end
+
+# function Base.setproperty!(opt::OptSummary, s::Symbol, x)
+#     if s == :fmin
+#         opt.fitlog[end] = (first(opt.fitlog[end]), x)
+#     elseif s == :finitial
+#         opt.fitlog[begin] = (first(opt.fitlog[begin]), x)
+#     elseif s == :final
+#         copyto!(first(last(opt.fitlog)), x)
+#     elseif s == :initial
+#         copyto!(first(first(opt.fitlog)), x)
+#     elseif s ∈ (:maxfeval, :feval)
+#         setfield!(opt, s, Int(x))
+#     else
+#         setfield!(opt, s, x)
+#     end
+# end
 
 function Base.show(io::IO, ::MIME"text/plain", s::OptSummary)
     println(io, "Initial parameter vector: ", s.initial)

--- a/src/optsummary.jl
+++ b/src/optsummary.jl
@@ -90,36 +90,6 @@ function OptSummary(
     )
 end
 
-# function Base.getproperty(opt::OptSummary, s::Symbol)
-#     if s == :fmin
-#         last(last(opt.fitlog))
-#     elseif s == :finitial
-#         last(first(opt.fitlog))
-#     elseif s == :final
-#         first(last(opt.fitlog))
-#     elseif s == :initial
-#         first(first(opt.fitlog))
-#     else
-#         getfield(opt, s)
-#     end
-# end
-
-# function Base.setproperty!(opt::OptSummary, s::Symbol, x)
-#     if s == :fmin
-#         opt.fitlog[end] = (first(opt.fitlog[end]), x)
-#     elseif s == :finitial
-#         opt.fitlog[begin] = (first(opt.fitlog[begin]), x)
-#     elseif s == :final
-#         copyto!(first(last(opt.fitlog)), x)
-#     elseif s == :initial
-#         copyto!(first(first(opt.fitlog)), x)
-#     elseif s ∈ (:maxfeval, :feval)
-#         setfield!(opt, s, Int(x))
-#     else
-#         setfield!(opt, s, x)
-#     end
-# end
-
 function Base.show(io::IO, ::MIME"text/plain", s::OptSummary)
     println(io, "Initial parameter vector: ", s.initial)
     println(io, "Initial objective value:  ", s.finitial)

--- a/src/optsummary.jl
+++ b/src/optsummary.jl
@@ -50,7 +50,7 @@ mutable struct OptSummary{T<:AbstractFloat}
     nAGQ::Integer           # don't really belong here but I needed a place to store them
     REML::Bool
     sigma::Union{T,Nothing}
-    fitlog::Vector{Tuple{Vector{T}, T}} # not SVector because we would need to parameterize on size (which breaks GLMM)
+    fitlog::Vector{Tuple{Vector{T},T}} # not SVector because we would need to parameterize on size (which breaks GLMM)
 end
 
 function OptSummary(

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -16,7 +16,6 @@ include("modelcache.jl")
     fitlog = []
     thin = 5
     gm0 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli(); fast=true, progress=false, fitlog, thin)
-    @show gm0.optsum.feval
     @test length(fitlog) == (div(gm0.optsum.feval, thin) + 1) # for the initial value
     @test first(fitlog) == (gm0.optsum.initial, gm0.optsum.finitial)
     @test gm0.lowerbd == zeros(1)

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -16,7 +16,8 @@ include("modelcache.jl")
     fitlog = []
     thin = 5
     gm0 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli(); fast=true, progress=false, fitlog, thin)
-    @test length(fitlog) == div(gm0.optsum.feval, thin) + 1 # for the initial value
+    @show gm0.optsum.feval
+    @test length(fitlog) == (div(gm0.optsum.feval, thin) + 1) # for the initial value
     @test first(fitlog) == (gm0.optsum.initial, gm0.optsum.finitial)
     @test gm0.lowerbd == zeros(1)
     @test isapprox(gm0.θ, [0.5720734451352923], atol=0.001)

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -13,9 +13,9 @@ include("modelcache.jl")
 
 @testset "contra" begin
     contra = dataset(:contra)
-    fitlog = []
     thin = 5
-    gm0 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli(); fast=true, progress=false, fitlog, thin)
+    gm0 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli(); fast=true, progress=false, thin)
+    fitlog = gm0.optsum.fitlog
     @test length(fitlog) == (div(gm0.optsum.feval, thin) + 1) # for the initial value
     @test first(fitlog) == (gm0.optsum.initial, gm0.optsum.finitial)
     @test gm0.lowerbd == zeros(1)

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -13,7 +13,11 @@ include("modelcache.jl")
 
 @testset "contra" begin
     contra = dataset(:contra)
-    gm0 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli(); fast=true, progress=false)
+    fitlog = []
+    thin = 5
+    gm0 = fit(MixedModel, only(gfms[:contra]), contra, Bernoulli(); fast=true, progress=false, fitlog, thin)
+    @test length(fitlog) == div(gm0.optsum.feval, thin) + 1 # for the initial value
+    @test first(fitlog) == (gm0.optsum.initial, gm0.optsum.finitial)
     @test gm0.lowerbd == zeros(1)
     @test isapprox(gm0.θ, [0.5720734451352923], atol=0.001)
     @test !issingular(gm0)

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -135,7 +135,7 @@ end
         fitlog = Tuple[]
         thin = 2
         refit!(fm1; REML=false, progress=false, fitlog, thin)
-        @test length(fitlog) == div(fm1.optsum.feval, thin) + 1 # for the initial value
+        @test length(fitlog) == (div(fm1.optsum.feval, thin) + 1) # for the initial value
         @test first(fitlog) == (fm1.optsum.initial, fm1.optsum.finitial)
     end
 end

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -132,9 +132,9 @@ end
     # since we're caching the fits, we should get it back to being correctly fitted
     # we also take this opportunity to test fitlog
     @testset "fitlog" begin
-        fitlog = Tuple[]
+        fitlog = fm1.optsum.fitlog
         thin = 2
-        refit!(fm1; REML=false, progress=false, fitlog, thin)
+        refit!(fm1; REML=false, progress=false, thin)
         @test length(fitlog) == (div(fm1.optsum.feval, thin) + 1) # for the initial value
         @test first(fitlog) == (fm1.optsum.initial, fm1.optsum.finitial)
     end

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -130,7 +130,14 @@ end
     @test isa(vc, Matrix{Float64})
     @test only(vc) ≈ 375.7167775 rtol=1.e-6
     # since we're caching the fits, we should get it back to being correctly fitted
-    refit!(fm1; REML=false, progress=false)
+    # we also take this opportunity to test fitlog
+    @testset "fitlog" begin
+        fitlog = Tuple[]
+        thin = 2
+        refit!(fm1; REML=false, progress=false, fitlog, thin)
+        @test length(fitlog) == div(fm1.optsum.feval, thin) + 1 # for the initial value
+        @test first(fitlog) == (fm1.optsum.initial, fm1.optsum.finitial)
+    end
 end
 
 @testset "Dyestuff2" begin


### PR DESCRIPTION
~Addresses (but does not close) #549 (because we want to change `OptSummary` later to be smarter about this).~

Closes #549. There is a minor inefficiency in that `initial`, `final`, `finitial`, `fmin` store information duplicated in the `fitlog`. Not duplicating this information (by cheating and using properties that redirect to the relevant field entries) turns out to make the bookkeeping a lot messier, so I've let this inefficiency remain (which also keeps better compatibility). I use `Vector` inside of the log instead of `SVector` because the changing size of the parameter vector in GLMM creates problems. 

It also seems that I might have found another case where julialang/julia#40048 isn't as fixed as we had hoped -- I get a big stackoverflow type inference dump as a Heisenbug when stepping through the `contra` testset, BUT it continues afterwards with the correct result. 