### PR TITLE
option for reduced precision in bootstrap results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.3.0 Release Notes
+========================
+* Add support for storing bootstrap results with lower precision [#566]
+
 MixedModels v4.2.0 Release Notes
 ========================
 * Add support for zerocorr models to the bootstrap [#561]
@@ -292,3 +296,4 @@ Package dependencies
 [#552]: https://github.com/JuliaStats/MixedModels.jl/issues/552
 [#553]: https://github.com/JuliaStats/MixedModels.jl/issues/553
 [#561]: https://github.com/JuliaStats/MixedModels.jl/issues/561
+[#566]: https://github.com/JuliaStats/MixedModels.jl/issues/566

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.2.1"
+version = "4.3.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -181,5 +181,6 @@ include("bootstrap.jl")
 include("blockdescription.jl")
 include("grouping.jl")
 include("mimeshow.jl")
+include("serialization.jl")
 
 end # module

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -71,7 +71,7 @@ function parametricbootstrap(
     rng::AbstractRNG,
     n::Integer,
     morig::MixedModel{T},
-    ftype=T;
+    ftype::Type{<:AbstractFloat}=T;
     β::AbstractVector=coef(morig),
     σ=morig.σ,
     θ::AbstractVector=morig.θ,

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -82,7 +82,9 @@ function parametricbootstrap(
         σ = T(σ)
     end
     β, θ = convert(Vector{T}, β), convert(Vector{T}, θ)
-    βsc, θsc, p, k, m = similar(ftype.(β)), similar(ftype.(θ)), length(β), length(θ), deepcopy(morig)
+    βsc, θsc = similar(ftype.(β)), similar(ftype.(θ))
+    p, k = length(β), length(θ)
+    m = deepcopy(morig)
 
     β_names = (Symbol.(fixefnames(morig))...,)
 

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -82,7 +82,7 @@ function parametricbootstrap(
         σ = T(σ)
     end
     β, θ = convert(Vector{T}, β), convert(Vector{T}, θ)
-    βsc, θsc, p, k, m = similar(β), similar(θ), length(β), length(θ), deepcopy(morig)
+    βsc, θsc, p, k, m = similar(ftype.(β)), similar(ftype.(θ)), length(β), length(θ), deepcopy(morig)
 
     β_names = (Symbol.(fixefnames(morig))...,)
 

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -35,13 +35,17 @@ struct MixedModelBootstrap{T<:AbstractFloat} <: MixedModelFitCollection{T}
 end
 
 """
-    parametricbootstrap([rng::AbstractRNG], nsamp::Integer, m::MixedModel{T};
-        β = coef(m), σ = m.σ, θ = m.θ, use_threads=false, hide_progress=false,
-        ftype=T)
+    parametricbootstrap([rng::AbstractRNG], nsamp::Integer, m::MixedModel{T}, ftype=T;
+        β = coef(m), σ = m.σ, θ = m.θ, use_threads=false, hide_progress=false)
 
 Perform `nsamp` parametric bootstrap replication fits of `m`, returning a `MixedModelBootstrap`.
 
 The default random number generator is `Random.GLOBAL_RNG`.
+
+`ftype` can be used to store the computed bootstrap values in a lower precision. `ftype` is
+not a named argument because named arguments are not used in method dispatch and thus
+specialization. In other words, having `ftype` as a positional argument has some potential
+performance benefits.
 
 # Named Arguments
 
@@ -51,7 +55,6 @@ families with a dispersion parameter.
 - `use_threads` determines whether or not to use thread-based parallelism.
 - `hide_progress` can be used to disable the progress bar. Note that the progress
 bar is automatically disabled for non-interactive (i.e. logging) contexts.
-- `ftype` can be used to store the computed bootstrap values in a lower precision.
 
 !!! note
     Note that `use_threads=true` may not offer a performance boost and may even
@@ -67,13 +70,13 @@ bar is automatically disabled for non-interactive (i.e. logging) contexts.
 function parametricbootstrap(
     rng::AbstractRNG,
     n::Integer,
-    morig::MixedModel{T};
+    morig::MixedModel{T},
+    ftype=T;
     β::AbstractVector=coef(morig),
     σ=morig.σ,
     θ::AbstractVector=morig.θ,
     use_threads::Bool=false,
     hide_progress::Bool=false,
-    ftype=T,
 ) where {T}
     if σ !== missing
         σ = T(σ)
@@ -123,12 +126,8 @@ function parametricbootstrap(
     )
 end
 
-function parametricbootstrap(
-    nsamp::Integer, m::MixedModel; β=m.β, σ=m.σ, θ=m.θ, use_threads=false
-)
-    return parametricbootstrap(
-        Random.GLOBAL_RNG, nsamp, m; β=β, σ=σ, θ=θ, use_threads=use_threads
-    )
+function parametricbootstrap(nsamp::Integer, m::MixedModel, args...; kwargs...)
+    return parametricbootstrap(Random.GLOBAL_RNG, nsamp, m, args...; kwargs...)
 end
 
 """

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -108,7 +108,7 @@ function parametricbootstrap(
         refit!(mod; progress=false)
         (
             objective=ftype.(mod.objective),
-            σ=ftype(mod.σ),
+            σ=ismissing(mod.σ) ? missing : ftype(mod.σ),
             β=NamedTuple{β_names}(fixef!(βsc, mod)),
             se=SVector{p,ftype}(stderror!(βsc, mod)),
             θ=SVector{k,ftype}(getθ!(θsc, mod)),

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -498,7 +498,7 @@ For full-rank models the length of `v` must be the rank of `X`.  For rank-defici
 the length of `v` can be the rank of `X` or the number of columns of `X`.  In the latter
 case the calculated coefficients are padded with -0.0 out to the number of columns.
 """
-function fixef!(v::AbstractVector{Tv}, m::LinearMixedModel{T}) where {Tv, T}
+function fixef!(v::AbstractVector{Tv}, m::LinearMixedModel{T}) where {Tv,T}
     Xtrm = m.feterm
     fill!(v, -zero(Tv))
     XyL = m.L[end]
@@ -547,7 +547,7 @@ Return the current covariance parameter vector.
 """
 getθ(m::LinearMixedModel{T}) where {T} = getθ!(Vector{T}(undef, length(m.parmap)), m)
 
-function getθ!(v::AbstractVector{Tv}, m::LinearMixedModel{T}) where {Tv, T}
+function getθ!(v::AbstractVector{Tv}, m::LinearMixedModel{T}) where {Tv,T}
     pmap = m.parmap
     if length(v) ≠ length(pmap)
         throw(
@@ -1102,7 +1102,7 @@ The length of `v` should be the total number of coefficients (i.e. `length(coef(
 When the model matrix is rank-deficient the coefficients forced to `-0.0` have an
 undefined (i.e. `NaN`) standard error.
 """
-function stderror!(v::AbstractVector{Tv}, m::LinearMixedModel{T}) where {Tv, T}
+function stderror!(v::AbstractVector{Tv}, m::LinearMixedModel{T}) where {Tv,T}
     L = feL(m)
     scr = Vector{T}(undef, size(L, 2))
     s = sdest(m)

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -619,8 +619,8 @@ StatsBase.islinear(m::LinearMixedModel) = true
 
 """
     _3blockL(::LinearMixedModel)
-    
-returns L in 3-block form: 
+
+returns L in 3-block form:
 - a Diagonal or UniformBlockDiagonal block
 - a dense rectangular block
 - and a dense lowertriangular block
@@ -911,76 +911,12 @@ function refit!(m::LinearMixedModel, y; kwargs...)
     return refit!(m; kwargs...)
 end
 
-"""
-    restoreoptsum!(m::LinearMixedModel, io::IO)
-    restoreoptsum!(m::LinearMixedModel, fnm::AbstractString)
-
-Read, check, and restore the `optsum` field from a JSON stream or filename.
-"""
-function restoreoptsum!(m::LinearMixedModel{T}, io::IO) where {T}
-    dict = JSON3.read(io)
-    ops = m.optsum
-    okay =
-        (setdiff(propertynames(ops), keys(dict)) == [:lowerbd]) &&
-        all(ops.lowerbd .≤ dict.initial) &&
-        all(ops.lowerbd .≤ dict.final)
-    if !okay
-        throw(ArgumentError("initial or final parameters in io do not satify lowerbd"))
-    end
-    for fld in (:feval, :finitial, :fmin, :ftol_rel, :ftol_abs, :maxfeval, :nAGQ, :REML)
-        setproperty!(ops, fld, getproperty(dict, fld))
-    end
-    ops.initial_step = copy(dict.initial_step)
-    ops.xtol_rel = copy(dict.xtol_rel)
-    copyto!(ops.initial, dict.initial)
-    copyto!(ops.final, dict.final)
-    for (v, f) in (:initial => :finitial, :final => :fmin)
-        if !isapprox(objective(updateL!(setθ!(m, getfield(ops, v)))), getfield(ops, f))
-            throw(ArgumentError("model m at $v does not give stored $f"))
-        end
-    end
-    ops.optimizer = Symbol(dict.optimizer)
-    ops.returnvalue = Symbol(dict.returnvalue)
-    # provides compatibility with fits saved before the introduction of fixed sigma
-    ops.sigma = get(dict, :sigma, nothing)
-    fitlog = get(dict, :fitlog, nothing)
-    ops.fitlog = if isnothing(fitlog)
-        # compat with fits saved before fitlog
-        [(ops.initial, ops.finitial, ops.final, ops.fmin)]
-    else
-        [(convert(Vector{T}, first(entry)), T(last(entry))) for entry in fitlog]
-    end
-    return m
-end
-
-function restoreoptsum!(m::LinearMixedModel, fnm::AbstractString)
-    open(fnm, "r") do io
-        restoreoptsum!(m, io)
-    end
-end
-
 function reweight!(m::LinearMixedModel, weights)
     sqrtwts = map!(sqrt, m.sqrtwts, weights)
     reweight!.(m.reterms, Ref(sqrtwts))
     reweight!(m.Xymat, sqrtwts)
     updateA!(m)
     return updateL!(m)
-end
-
-"""
-    saveoptsum(io::IO, m::LinearMixedModel)
-    saveoptsum(fnm::AbstractString, m::LinearMixedModel)
-
-Save `m.optsum` (w/o the `lowerbd` field) in JSON format to an IO stream or a file
-
-The reason for omitting the `lowerbd` field is because it often contains `-Inf`
-values that are not allowed in JSON.
-"""
-saveoptsum(io::IO, m::LinearMixedModel) = JSON3.write(io, m.optsum)
-function saveoptsum(fnm::AbstractString, m::LinearMixedModel)
-    open(fnm, "w") do io
-        saveoptsum(io, m)
-    end
 end
 
 """

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -498,9 +498,9 @@ For full-rank models the length of `v` must be the rank of `X`.  For rank-defici
 the length of `v` can be the rank of `X` or the number of columns of `X`.  In the latter
 case the calculated coefficients are padded with -0.0 out to the number of columns.
 """
-function fixef!(v::AbstractVector{T}, m::LinearMixedModel{T}) where {T}
+function fixef!(v::AbstractVector{Tv}, m::LinearMixedModel{T}) where {Tv, T}
     Xtrm = m.feterm
-    fill!(v, -zero(T))
+    fill!(v, -zero(Tv))
     XyL = m.L[end]
     L = feL(m)
     k = size(XyL, 1)
@@ -547,7 +547,7 @@ Return the current covariance parameter vector.
 """
 getθ(m::LinearMixedModel{T}) where {T} = getθ!(Vector{T}(undef, length(m.parmap)), m)
 
-function getθ!(v::AbstractVector{T}, m::LinearMixedModel{T}) where {T}
+function getθ!(v::AbstractVector{Tv}, m::LinearMixedModel{T}) where {Tv, T}
     pmap = m.parmap
     if length(v) ≠ length(pmap)
         throw(
@@ -1102,11 +1102,11 @@ The length of `v` should be the total number of coefficients (i.e. `length(coef(
 When the model matrix is rank-deficient the coefficients forced to `-0.0` have an
 undefined (i.e. `NaN`) standard error.
 """
-function stderror!(v::AbstractVector{T}, m::LinearMixedModel{T}) where {T}
+function stderror!(v::AbstractVector{Tv}, m::LinearMixedModel{T}) where {Tv, T}
     L = feL(m)
     scr = Vector{T}(undef, size(L, 2))
     s = sdest(m)
-    fill!(v, zero(T) / zero(T))  # initialize to appropriate NaN for rank-deficient case
+    fill!(v, zero(Tv) / zero(Tv))  # initialize to appropriate NaN for rank-deficient case
     for i in eachindex(scr)
         fill!(scr, false)
         scr[i] = true

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -63,3 +63,20 @@ function saveoptsum(fnm::AbstractString, m::LinearMixedModel)
         saveoptsum(io, m)
     end
 end
+
+# λ::Vector{<:Union{LowerTriangular{T,Matrix{T}},Diagonal{T,Vector{T}}}}
+# inds::Vector{Vector{Int}}
+# lowerbd::Vector{T}
+# fcnames::NamedTuple
+
+function savefitcollection(fnm::AbstractString, bs::MixedModelFitCollection; ftype=Float32)
+    # idea:
+    # 1. write the fits field as an arrow table
+    # - need to convert to column table
+    # - need to deal with static arrays
+    # - need to convert floats to ftype (maybe do this before column table to avoid allocations?)
+    # 2. write fcnames as metadata ? needs to be Dict{String, String}
+    # 3. write λ, inds, lowerbd, as the first row in their own columns, with the rest of the values missing
+    #    and see if comrpession/runlength encoding helps (compare size of table from step 1 to size of table after 3)
+
+end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -62,19 +62,5 @@ function saveoptsum(fnm::AbstractString, m::LinearMixedModel)
     end
 end
 
-# λ::Vector{<:Union{LowerTriangular{T,Matrix{T}},Diagonal{T,Vector{T}}}}
-# inds::Vector{Vector{Int}}
-# lowerbd::Vector{T}
-# fcnames::NamedTuple
-
-function savefitcollection(fnm::AbstractString, bs::MixedModelFitCollection; ftype=Float32)
-    # idea:
-    # 1. write the fits field as an arrow table
-    # - need to convert to column table
-    # - need to deal with static arrays
-    # - need to convert floats to ftype (maybe do this before column table to avoid allocations?)
-    # 2. write fcnames as metadata ? needs to be Dict{String, String}
-    # 3. write λ, inds, lowerbd, as the first row in their own columns, with the rest of the values missing
-    #    and see if comrpession/runlength encoding helps (compare size of table from step 1 to size of table after 3)
-
-end
+# TODO: write methods for GLMM
+# TODO, maybe: something nice for the MixedModelBootstrap

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -1,0 +1,65 @@
+"""
+    restoreoptsum!(m::LinearMixedModel, io::IO)
+    restoreoptsum!(m::LinearMixedModel, fnm::AbstractString)
+
+Read, check, and restore the `optsum` field from a JSON stream or filename.
+"""
+function restoreoptsum!(m::LinearMixedModel{T}, io::IO) where {T}
+    dict = JSON3.read(io)
+    ops = m.optsum
+    okay =
+        (setdiff(propertynames(ops), keys(dict)) == [:lowerbd]) &&
+        all(ops.lowerbd .≤ dict.initial) &&
+        all(ops.lowerbd .≤ dict.final)
+    if !okay
+        throw(ArgumentError("initial or final parameters in io do not satify lowerbd"))
+    end
+    for fld in (:feval, :finitial, :fmin, :ftol_rel, :ftol_abs, :maxfeval, :nAGQ, :REML)
+        setproperty!(ops, fld, getproperty(dict, fld))
+    end
+    ops.initial_step = copy(dict.initial_step)
+    ops.xtol_rel = copy(dict.xtol_rel)
+    copyto!(ops.initial, dict.initial)
+    copyto!(ops.final, dict.final)
+    for (v, f) in (:initial => :finitial, :final => :fmin)
+        if !isapprox(objective(updateL!(setθ!(m, getfield(ops, v)))), getfield(ops, f))
+            throw(ArgumentError("model m at $v does not give stored $f"))
+        end
+    end
+    ops.optimizer = Symbol(dict.optimizer)
+    ops.returnvalue = Symbol(dict.returnvalue)
+    # provides compatibility with fits saved before the introduction of fixed sigma
+    ops.sigma = get(dict, :sigma, nothing)
+    fitlog = get(dict, :fitlog, nothing)
+    ops.fitlog = if isnothing(fitlog)
+        # compat with fits saved before fitlog
+        [(ops.initial, ops.finitial, ops.final, ops.fmin)]
+    else
+        [(convert(Vector{T}, first(entry)), T(last(entry))) for entry in fitlog]
+    end
+    return m
+end
+
+function restoreoptsum!(m::LinearMixedModel, fnm::AbstractString)
+    open(fnm, "r") do io
+        restoreoptsum!(m, io)
+    end
+end
+
+
+
+"""
+    saveoptsum(io::IO, m::LinearMixedModel)
+    saveoptsum(fnm::AbstractString, m::LinearMixedModel)
+
+Save `m.optsum` (w/o the `lowerbd` field) in JSON format to an IO stream or a file
+
+The reason for omitting the `lowerbd` field is because it often contains `-Inf`
+values that are not allowed in JSON.
+"""
+saveoptsum(io::IO, m::LinearMixedModel) = JSON3.write(io, m.optsum)
+function saveoptsum(fnm::AbstractString, m::LinearMixedModel)
+    open(fnm, "w") do io
+        saveoptsum(io, m)
+    end
+end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -46,8 +46,6 @@ function restoreoptsum!(m::LinearMixedModel, fnm::AbstractString)
     end
 end
 
-
-
 """
     saveoptsum(io::IO, m::LinearMixedModel)
     saveoptsum(fnm::AbstractString, m::LinearMixedModel)

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -8,7 +8,7 @@ using Statistics
 using Tables
 using Test
 
-using MixedModels: dataset
+using MixedModels: dataset, MixedModelBootstrap
 
 include("modelcache.jl")
 
@@ -104,10 +104,11 @@ end
         @test sum(issingular(bsamp)) == sum(issingular(bsamp_threaded))
     end
 
-    @testset "zerocorr + Base.length" begin
+    @testset "zerocorr + Base.length + ftype" begin
         fmzc = models(:sleepstudy)[2]
-        pbzc = parametricbootstrap(MersenneTwister(42), 5, fmzc)
+        pbzc = parametricbootstrap(MersenneTwister(42), 5, fmzc, Float16)
         @test length(pbzc) == 5
+        @test typeof(pbzc) == MixedModelBootstrap{Float16}
     end
 
     @testset "Bernoulli simulate! and GLMM boostrap" begin


### PR DESCRIPTION
~more just organizing my thoughts than any real effort~

Moved some serialization things over to their own file and gave us a TODO list. For now, I would recommend that users use JLD2 to store their bootstrap results and then constrain their JLD2 and MixedModels major version.

