### PR TITLE
Fix allpars for zerocorr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 MixedModels v4.3.0 Release Notes
 ========================
 * Add support for storing bootstrap results with lower precision [#566]
+* Improved support for zerocorr models to the bootstrap [#570]
 
 MixedModels v4.2.0 Release Notes
 ========================
@@ -297,3 +298,4 @@ Package dependencies
 [#553]: https://github.com/JuliaStats/MixedModels.jl/issues/553
 [#561]: https://github.com/JuliaStats/MixedModels.jl/issues/561
 [#566]: https://github.com/JuliaStats/MixedModels.jl/issues/566
+[#570]: https://github.com/JuliaStats/MixedModels.jl/issues/570

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 MixedModels v4.3.0 Release Notes
 ========================
 * Add support for storing bootstrap results with lower precision [#566]
-* Improved support for zerocorr models to the bootstrap [#570]
+* Improved support for zerocorr models in the bootstrap [#570]
 
 MixedModels v4.2.0 Release Notes
 ========================

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.3.1"
+version = "4.3.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.3.0"
+version = "4.3.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/src/prediction.md
+++ b/docs/src/prediction.md
@@ -12,6 +12,7 @@ slp = DataFrame(MixedModels.dataset(:sleepstudy))
 slpm = fit(MixedModel, @formula(reaction ~ 1 + days + (1|subj)), slp)
 DisplayAs.Text(slpm) # hide
 ```
+
 ## Prediction
 
 The simplest form of prediction are the fitted values from the model: they are indeed the model's predictions for the observed data.
@@ -79,8 +80,9 @@ predict(slpm, slp2; new_re_levels=:population)
 For generalized linear mixed models, there is an additional keyword argument to `predict`: `type` specifies whether the predictions are returned on the scale of the linear predictor (`:linpred`) or on the level of the response `(:response)` (i.e. the level at which the values were originally observed).
 
 ```@example Main
-cbpp = MixedModels.dataset(:cbpp)
-gm = fit(MixedModel, @formula((incid/hsz) ~ 1 + period + (1|herd)), cbpp, Binomial(), wts=float(cbpp.hsz))
+cbpp = DataFrame(MixedModels.dataset(:cbpp))
+cbpp.rate = cbpp.incid ./ cbpp.hsz
+gm = fit(MixedModel, @formula(rate ~ 1 + period + (1|herd)), cbpp, Binomial(), wts=float(cbpp.hsz))
 predict(gm, cbpp; type=:response) ≈ fitted(gm)
 ```
 

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -137,6 +137,11 @@ end
 
 Return a tidy (column)table with the parameter estimates spread into columns
 of `iter`, `type`, `group`, `name` and `value`.
+
+!!! warning
+    Currently, correlations that are systematically zero are included in the
+    the result. This may change in a future release without being considered
+    a breaking change.
 """
 function allpars(bsamp::MixedModelFitCollection{T}) where {T}
     fits, λ, fcnames = bsamp.fits, bsamp.λ, bsamp.fcnames
@@ -244,7 +249,7 @@ function setθ!(bsamp::MixedModelFitCollection, i::Integer)
     θ = bsamp.fits[i].θ
     offset = 0
     for (λ, inds) in zip(bsamp.λ, bsamp.inds)
-        λdat = λ.data
+        λdat = _getdata(λ)
         fill!(λdat, false)
         for j in eachindex(inds)
             λdat[inds[j]] = θ[j + offset]
@@ -253,6 +258,9 @@ function setθ!(bsamp::MixedModelFitCollection, i::Integer)
     end
     return bsamp
 end
+
+_getdata(x::Diagonal) = x
+_getdata(x::LowerTriangular) = x.data
 
 """
     shortestcovint(v, level = 0.95)
@@ -277,7 +285,12 @@ end
 """
     shortestcovint(bsamp::MixedModelBootstrap, level = 0.95)
 
-Return the shortest interval containing `level` proportion for each parameter from `bsamp.allpars`
+Return the shortest interval containing `level` proportion for each parameter from `bsamp.allpars`.
+
+!!! warning
+    Currently, correlations that are systematically zero are included in the
+    the result. This may change in a future release without being considered
+    a breaking change.
 """
 function shortestcovint(bsamp::MixedModelBootstrap{T}, level=0.95) where {T}
     allpars = bsamp.allpars

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -89,7 +89,8 @@ function _predict(m::MixedModel{T}, newdata, β; new_re_levels) where {T}
     # we get type stability via constant propogation on `new_re_levels`
     y, mnew = let ytemp = ones(T, length(first(newdata)))
         f, contr = _abstractify_grouping(m.formula)
-        if !(f.lhs.sym in Tables.columnnames(newdata)) || any(ismissing, newdata[f.lhs.sym])
+        respname = Symbol(f.lhs)
+        if !(respname in Tables.columnnames(newdata)) || any(ismissing, newdata[respname])
             throw(
                 ArgumentError(
                     "Response column must be initialized to a non-missing numeric value.",

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -108,6 +108,7 @@ end
         fmzc = models(:sleepstudy)[2]
         pbzc = parametricbootstrap(MersenneTwister(42), 5, fmzc, Float16)
         @test length(pbzc) == 5
+        @test Tables.istable(shortestcovint(pbzc))
         @test typeof(pbzc) == MixedModelBootstrap{Float16}
     end
 


### PR DESCRIPTION
Closes #569 

There seems to be a new issue in the docs when `predict` is called on a model with a function term (e.g. division) in the response. For now, I've just made a work-around.