### PR TITLE
Support for bootstrapping models with a mixture of correlation structures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 MixedModels v4.4.0 Release Notes
 ========================
+* Fix type parameterization in MixedModelsBootstrap to support models with a mixture of correlation structures (i.e. `zerocorr` in some but not all RE terms) [#577]
+
+MixedModels v4.4.0 Release Notes
+========================
 * Add a constructor for the abstract type `MixedModel` that delegates to `LinearMixedModel` or `GeneralizedLinearMixedModel`. [#572]
 * Compat for Arrow.jl 2.0 [#573]
 
@@ -306,3 +310,4 @@ Package dependencies
 [#570]: https://github.com/JuliaStats/MixedModels.jl/issues/570
 [#572]: https://github.com/JuliaStats/MixedModels.jl/issues/572
 [#573]: https://github.com/JuliaStats/MixedModels.jl/issues/573
+[#577]: https://github.com/JuliaStats/MixedModels.jl/issues/577

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.4.0"
+version = "4.4.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -28,7 +28,7 @@ and correlations of the random-effects terms.
 """
 struct MixedModelBootstrap{T<:AbstractFloat} <: MixedModelFitCollection{T}
     fits::Vector
-    λ::Vector{<:Union{LowerTriangular{T,Matrix{T}},Diagonal{T,Vector{T}}}}
+    λ::Vector{Union{LowerTriangular{T},Diagonal{T}}}
     inds::Vector{Vector{Int}}
     lowerbd::Vector{T}
     fcnames::NamedTuple

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -112,6 +112,14 @@ end
         @test typeof(pbzc) == MixedModelBootstrap{Float16}
     end
 
+    @testset "zerocorr + not zerocorr" begin
+        form_zc_not = @formula(rt_trunc ~ 1 + spkr * prec * load +
+                                         (1 + spkr + prec + load | subj) +
+                                 zerocorr(1 + spkr + prec + load | item))
+        fmzcnot = fit(MixedModel, form_zc_not, dataset(:kb07))
+        pbzcnot = parametricbootstrap(MersenneTwister(42), 2, fmzcnot, Float16)
+    end
+
     @testset "Bernoulli simulate! and GLMM boostrap" begin
         contra = dataset(:contra)
         # need a model with fast=false to test that we only


### PR DESCRIPTION
This changes the type constraint on `MixedModelsBootstrap.λ` to allow bootstrapping models with a mixture of correlation structures, e.g. some `zerocorr` and some non `zerocorr` random effects.
