### PR TITLE
Allow LMM to init GLMM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.5.0"
+version = "4.6.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -167,16 +167,9 @@ function fit(
     tbl,
     d::Distribution=Normal(),
     l::Link=canonicallink(d);
-    kwargs...
+    kwargs...,
 )
-    return fit(
-        GeneralizedLinearMixedModel,
-        f,
-        columntable(tbl),
-        d,
-        l;
-        kwargs...
-    )
+    return fit(GeneralizedLinearMixedModel, f, columntable(tbl), d, l; kwargs...)
 end
 
 function fit(
@@ -188,13 +181,10 @@ function fit(
     wts=[],
     contrasts=Dict{Symbol,Any}(),
     offset=[],
-    kwargs...
+    kwargs...,
 )
     return fit!(
-        GeneralizedLinearMixedModel(
-            f, tbl, d, l; wts, offset, contrasts
-        );
-        kwargs...
+        GeneralizedLinearMixedModel(f, tbl, d, l; wts, offset, contrasts); kwargs...
     )
 end
 
@@ -204,16 +194,9 @@ function fit(
     tbl,
     d::Distribution,
     l::Link=canonicallink(d);
-    kwargs...
+    kwargs...,
 )
-    return fit(
-        GeneralizedLinearMixedModel,
-        f,
-        tbl,
-        d,
-        l;
-        kwargs...
-    )
+    return fit(GeneralizedLinearMixedModel, f, tbl, d, l; kwargs...)
 end
 
 """
@@ -249,7 +232,8 @@ function fit!(
     lm = m.LMM
     optsum = lm.optsum
 
-    issubset(lmminit, [:θ, :β]) || throw(ArgumentError("Invalid parameter selection for lmminit"))
+    issubset(lmminit, [:θ, :β]) ||
+        throw(ArgumentError("Invalid parameter selection for lmminit"))
 
     if optsum.feval > 0
         throw(ArgumentError("This model has already been fitted. Use refit!() instead."))

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -202,7 +202,8 @@ end
 """
     fit!(m::GeneralizedLinearMixedModel; fast=false, nAGQ=1,
                                          verbose=false, progress=true,
-                                         thin::Int=1)
+                                         thin::Int=1,
+                                         init_from_lmm=Set())
 
 Optimize the objective function for `m`.
 
@@ -217,6 +218,25 @@ and it may not be shown at all for models that are optimized quickly.
 If `verbose` is `true`, then both the intermediate results of both the nonlinear optimization and PIRLS are also displayed on standard output.
 
 At every `thin`th iteration  is recorded in `fitlog`, optimization progress is saved in `m.optsum.fitlog`.
+
+By default, the starting values for model fitting are taken from a (non mixed,
+i.e. marginal ) GLM fit. Experience with larger datasets (many thousands of
+observations and/or hundreds of levels of the grouping variables) has suggested
+that fittinga (Gaussian) linear mixed model on the untransformed data may
+provide better starting values and thus overall faster fits even though an
+entire LMM must be fit before the GLMM can be fit. `init_from_lmm` can be used
+to specify which starting values from an LMM with. Valid options are any
+collection (array, set, etc.) containing one or more of `:β` and `:θ`, the
+default is the empty set.
+
+!!! note
+    Initializing from an LMM requires fitting the entire LMM first, so when
+    `progress=true`, there will be two progress bars: first for the LMM, then
+    for the GLMM.
+
+!!! warning
+    The `init_from_lmm` functionality is experimental and may change or be removed entirely
+    without being considered a breaking change.
 """
 function fit!(
     m::GeneralizedLinearMixedModel{T};
@@ -225,15 +245,15 @@ function fit!(
     nAGQ::Integer=1,
     progress::Bool=true,
     thin::Int=typemax(Int),
-    lmminit=Set(),
+    init_from_lmm=Set(),
 ) where {T}
     β = copy(m.β)
     θ = copy(m.θ)
     lm = m.LMM
     optsum = lm.optsum
 
-    issubset(lmminit, [:θ, :β]) ||
-        throw(ArgumentError("Invalid parameter selection for lmminit"))
+    issubset(init_from_lmm, [:θ, :β]) ||
+        throw(ArgumentError("Invalid parameter selection for init_from_lmm"))
 
     if optsum.feval > 0
         throw(ArgumentError("This model has already been fitted. Use refit!() instead."))
@@ -243,10 +263,10 @@ function fit!(
         throw(ArgumentError("The response is constant and thus model fitting has failed"))
     end
 
-    if !isempty(lmminit)
-        fit!(lm)
-        :θ in lmminit && copyto!(θ, lm.θ)
-        :β in lmminit && copyto!(β, lm.β)
+    if !isempty(init_from_lmm)
+        fit!(lm; progress)
+        :θ in init_from_lmm && copyto!(θ, lm.θ)
+        :β in init_from_lmm && copyto!(β, lm.β)
         unfit!(lm)
     end
 

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -259,7 +259,7 @@ function fit!(
         throw(ArgumentError("The response is constant and thus model fitting has failed"))
     end
 
-    if !isnothing(lmminit)
+    if !isempty(lmminit)
         fit!(lm)
         :θ in lmminit && copyto!(θ, lm.θ)
         :β in lmminit && copyto!(β, lm.β)

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -167,14 +167,7 @@ function fit(
     tbl,
     d::Distribution=Normal(),
     l::Link=canonicallink(d);
-    wts=[],
-    contrasts=Dict{Symbol,Any}(),
-    offset=[],
-    verbose::Bool=false,
-    fast::Bool=false,
-    nAGQ::Integer=1,
-    progress::Bool=true,
-    thin::Int=typemax(Int),
+    kwargs...
 )
     return fit(
         GeneralizedLinearMixedModel,
@@ -182,14 +175,7 @@ function fit(
         columntable(tbl),
         d,
         l;
-        wts,
-        offset,
-        contrasts,
-        verbose,
-        fast,
-        nAGQ,
-        progress,
-        thin,
+        kwargs...
     )
 end
 
@@ -202,21 +188,13 @@ function fit(
     wts=[],
     contrasts=Dict{Symbol,Any}(),
     offset=[],
-    verbose::Bool=false,
-    fast::Bool=false,
-    nAGQ::Integer=1,
-    progress::Bool=true,
-    thin::Int=typemax(Int),
+    kwargs...
 )
     return fit!(
         GeneralizedLinearMixedModel(
-            f, tbl, d, l; wts=wts, offset=offset, contrasts=contrasts
+            f, tbl, d, l; wts, offset, contrasts
         );
-        verbose,
-        fast,
-        nAGQ,
-        progress,
-        thin,
+        kwargs...
     )
 end
 
@@ -226,15 +204,7 @@ function fit(
     tbl,
     d::Distribution,
     l::Link=canonicallink(d);
-    wts=[],
-    contrasts=Dict{Symbol,Any}(),
-    offset=[],
-    verbose::Bool=false,
-    REML::Bool=false,
-    fast::Bool=false,
-    nAGQ::Integer=1,
-    progress::Bool=true,
-    thin::Int=typemax(Int),
+    kwargs...
 )
     return fit(
         GeneralizedLinearMixedModel,
@@ -242,14 +212,7 @@ function fit(
         tbl,
         d,
         l;
-        wts,
-        contrasts,
-        offset,
-        verbose,
-        fast,
-        nAGQ,
-        progress,
-        thin,
+        kwargs...
     )
 end
 

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -90,11 +90,11 @@ end
 
 @testset "cbpp" begin
     cbpp = dataset(:cbpp)
-    gm2 = fit(MixedModel, first(gfms[:cbpp]), cbpp, Binomial(); wts=float(cbpp.hsz), progress=false)
+    gm2 = fit(MixedModel, first(gfms[:cbpp]), cbpp, Binomial(); wts=float(cbpp.hsz), progress=false, lmminit=[:β, :θ])
     @test weights(gm2) == cbpp.hsz
     @test deviance(gm2,true) ≈ 100.09585619892968 atol=0.0001
     @test sum(abs2, gm2.u[1]) ≈ 9.723054788538546 atol=0.0001
-    @test logdet(gm2) ≈ 16.90105378801136 atol=0.0001
+    @test logdet(gm2) ≈ 16.90105378801136 atol=0.001
     @test isapprox(sum(gm2.resp.devresid), 73.47174762237978, atol=0.001)
     @test isapprox(loglikelihood(gm2), -92.02628186840045, atol=0.001)
     @test !dispersion_parameter(gm2)

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -90,7 +90,7 @@ end
 
 @testset "cbpp" begin
     cbpp = dataset(:cbpp)
-    gm2 = fit(MixedModel, first(gfms[:cbpp]), cbpp, Binomial(); wts=float(cbpp.hsz), progress=false, lmminit=[:β, :θ])
+    gm2 = fit(MixedModel, first(gfms[:cbpp]), cbpp, Binomial(); wts=float(cbpp.hsz), progress=false, init_from_lmm=[:β, :θ])
     @test weights(gm2) == cbpp.hsz
     @test deviance(gm2,true) ≈ 100.09585619892968 atol=0.0001
     @test sum(abs2, gm2.u[1]) ≈ 9.723054788538546 atol=0.0001


### PR DESCRIPTION
Benchmarking suggests that the GLM inits we're currently using are the best for small models (although at a few hundred millisecond total difference in the fit, it's realistically a wash). But things get more interesting if we look at big models.

Here's an example from the English Lexicon project data -- I've split it into two plots because the scale changes pretty dramatically.

**First 50 iterations (after LMM fitting when the LMM is used)**  
![First 50 iterations (after the LMM was fit for models with an LMM)](https://user-images.githubusercontent.com/1677783/148011176-5f23ab7a-1db3-4bde-bc76-3657a7a0adf2.png)

**All successive iterations**
![All iterations after 50](https://user-images.githubusercontent.com/1677783/148011209-10f1631f-d7cf-4ea3-bd4e-bf227435f854.png)

Here's the dataframe showing the progress (wrapped in a zip file to make GitHub happy):
[glmm_fitlog_by_init.arrow.zip](https://github.com/JuliaStats/MixedModels.jl/files/7805404/glmm_fitlog_by_init.arrow.zip)

The relevant timing info
```julia
Minimizing 973   Time: 1:42:50 ( 6.34  s/it) # GLM init
6179.284576 seconds (1.23 M allocations: 1.374 GiB, 0.00% gc time, 0.00% compilation time)
Minimizing 38    Time: 0:00:04 ( 0.12  s/it) # LMM being fit....
Minimizing 113   Time: 0:11:16 ( 5.98  s/it) # beta and theta from LMM
689.532497 seconds (285.49 k allocations: 1.341 GiB, 0.06% gc time)
Minimizing 38    Time: 0:00:04 ( 0.12  s/it) 
Minimizing 556   Time: 1:00:04 ( 6.48  s/it) # theta from LMM
3618.443314 seconds (767.97 k allocations: 1.358 GiB, 0.01% gc time)
Minimizing 38    Time: 0:00:04 ( 0.12  s/it)
Minimizing 113 Time: 0:12:10 ( 6.47  s/it) # beta from LMM
744.312527 seconds (285.59 k allocations: 1.341 GiB, 0.08% gc time)
```

It could be interesting plot the norm of successive differences between the parameter vector so that we can see how much movement we're getting -- and maybe how much of that is change in beta and how much is change in theta.


@dmbates 


