### PR TITLE
broaden shortestcovint to fit collection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.6.1 Release Notes
+========================
+* Loosen type restriction on `shortestcovint(::MixedModelBootstrap)` to `shortestcovint(::MixedModelFitCollection)`. [#598]
+
 MixedModels v4.6.0 Release Notes
 ========================
 * Experimental support for initializing `GeneralizedLinearMixedModel` fits from a linear mixed model instead of a marginal (non-mixed) generalized linear model. [#588]
@@ -322,3 +326,4 @@ Package dependencies
 [#577]: https://github.com/JuliaStats/MixedModels.jl/issues/577
 [#578]: https://github.com/JuliaStats/MixedModels.jl/issues/578
 [#588]: https://github.com/JuliaStats/MixedModels.jl/issues/588
+[#598]: https://github.com/JuliaStats/MixedModels.jl/issues/598

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.6.0"
+version = "4.6.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -283,7 +283,7 @@ function shortestcovint(v, level=0.95)
 end
 
 """
-    shortestcovint(bsamp::MixedModelBootstrap, level = 0.95)
+    shortestcovint(bsamp::MixedModelFitCollection, level = 0.95)
 
 Return the shortest interval containing `level` proportion for each parameter from `bsamp.allpars`.
 
@@ -292,7 +292,7 @@ Return the shortest interval containing `level` proportion for each parameter fr
     the result. This may change in a future release without being considered
     a breaking change.
 """
-function shortestcovint(bsamp::MixedModelBootstrap{T}, level=0.95) where {T}
+function shortestcovint(bsamp::MixedModelFitCollection{T}, level=0.95) where {T}
     allpars = bsamp.allpars
     pars = unique(zip(allpars.type, allpars.group, allpars.names))
 


### PR DESCRIPTION
I broadened the type restriction so that some of the stuff I'm working on in MixedModelsPermutations can use `shortestcovint` without adding needing a new method definition for `MixedModelPermutation`. 

Thanks for contributing!

Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately
