### PR TITLE
rework `predict` docstring

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.6.2 Release Notes
+========================
+* Changed the explanation of `new_re_levels` in a way that is clearer about the behavior when there are multiple grouping variables. [#603]
+
 MixedModels v4.6.1 Release Notes
 ========================
 * Loosen type restriction on `shortestcovint(::MixedModelBootstrap)` to `shortestcovint(::MixedModelFitCollection)`. [#598]
@@ -327,3 +331,4 @@ Package dependencies
 [#578]: https://github.com/JuliaStats/MixedModels.jl/issues/578
 [#588]: https://github.com/JuliaStats/MixedModels.jl/issues/588
 [#598]: https://github.com/JuliaStats/MixedModels.jl/issues/598
+[#603]: https://github.com/JuliaStats/MixedModels.jl/issues/603

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 MixedModels v4.6.2 Release Notes
 ========================
-* Changed the explanation of `new_re_levels` in a way that is clearer about the behavior when there are multiple grouping variables. [#603]
+* Changed the explanation of `predict`'s keyword argument `new_re_levels` in a way that is clearer about the behavior when there are multiple grouping variables. [#603]
+* Fix the default behavior of `new_re_levels=:missing` to match the docstring. Previously, the default was `:population`, in disagreement with the docstring. [#603]
 
 MixedModels v4.6.1 Release Notes
 ========================

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.6.1"
+version = "4.6.2"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/src/prediction.md
+++ b/docs/src/prediction.md
@@ -50,7 +50,7 @@ In the case where there are new levels of the grouping variable, these methods d
 ```@example Main
 # create a new level
 slp2 = transform(slp, :subj => ByRow(x -> (x == "S308" ? "NEW" : x)) => :subj)
-DisplayAs.Text(ans)
+DisplayAs.Text(ans) # hide
 ```
 
 ```@example Main

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -47,6 +47,11 @@ while including previously observed levels of the other grouping variables.
 In the future, it may be possible to specify a subset of the grouping variables
 or overall random-effects structure to use, but not at this time.
 
+!!! note
+    `new_re_levels` impacts only the behavior for previously unobserved random
+    effects levels, i.e. new RE levels. For previously observed random effects
+    levels, predictions take both the fixed and random effects into account.
+
 For `GeneralizedLinearMixedModel`, the `type` parameter specifies
 whether the predictions should be returned on the scale of linear predictor
 (`:linpred`) or on the response scale (`:response`). If you don't know the

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -26,18 +26,25 @@ Predict response for new data.
     as such may use a large amount of memory when `newdata` is large.
 
 The keyword argument `new_re_levels` specifies how previously unobserved
-values of the grouping variable are handled. Possible values are
-`:population` (return population values, i.e. fixed-effects only),
-`:missing` (return `missing`), `:error` (error on this condition;
-the error type is an implementation detail). If you want simulated values
-for unobserved levels of the grouping variable, consider the
-[`simulate!`](@ref) and `simulate` methods.
+values of the grouping variable are handled. Possible values are:
+
+- `:population`: return population values for the relevant grouping varible.
+   If all grouping variables have new levels, then this is equivalent to the
+   just the fixed effects.
+- `:missing`: return `missing`.
+- `:error`: error on this condition. The error type is an implementation detail:
+   you should rely on a particular type of error being returned.
+
+If you want simulated values for unobserved levels of the grouping variable,
+consider the [`simulate!`](@ref) and `simulate` methods.
 
 Predictions based purely on the fixed effects can be obtained by
 specifying previously unobserved levels of the random effects and setting
-`new_re_levels=:population`. In the future, it may be possible to specify
-a subset of the grouping variables or overall random-effects structure to use,
-but not at this time.
+`new_re_levels=:population`. Similarly, the contribution of a particular
+grouping variable can be excluded by specifying previously unobserved levels,
+while including previously observed levels of the other grouping variables.
+In the future, it may be possible to specify a subset of the grouping variables
+or overall random-effects structure to use,but not at this time.
 
 For `GeneralizedLinearMixedModel`, the `type` parameter specifies
 whether the predictions should be returned on the scale of linear predictor

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -28,23 +28,24 @@ Predict response for new data.
 The keyword argument `new_re_levels` specifies how previously unobserved
 values of the grouping variable are handled. Possible values are:
 
-- `:population`: return population values for the relevant grouping varible.
+- `:population`: return population values for the relevant grouping variable.
+   In other words, treat the associated random effect as 0.
    If all grouping variables have new levels, then this is equivalent to the
    just the fixed effects.
 - `:missing`: return `missing`.
 - `:error`: error on this condition. The error type is an implementation detail:
-   you should rely on a particular type of error being returned.
+   you should not rely on a particular type of error being returned.
 
 If you want simulated values for unobserved levels of the grouping variable,
 consider the [`simulate!`](@ref) and `simulate` methods.
 
 Predictions based purely on the fixed effects can be obtained by
 specifying previously unobserved levels of the random effects and setting
-`new_re_levels=:population`. Similarly, the contribution of a particular
+`new_re_levels=:population`. Similarly, the contribution of any
 grouping variable can be excluded by specifying previously unobserved levels,
 while including previously observed levels of the other grouping variables.
 In the future, it may be possible to specify a subset of the grouping variables
-or overall random-effects structure to use,but not at this time.
+or overall random-effects structure to use, but not at this time.
 
 For `GeneralizedLinearMixedModel`, the `type` parameter specifies
 whether the predictions should be returned on the scale of linear predictor

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -56,7 +56,7 @@ Regression weights are not yet supported in prediction.
 Similarly, offsets are also not supported for `GeneralizedLinearMixedModel`.
 """
 function StatsBase.predict(
-    m::LinearMixedModel, newdata::Tables.ColumnTable; new_re_levels=:population
+    m::LinearMixedModel, newdata::Tables.ColumnTable; new_re_levels=:missing
 )
     return _predict(m, newdata, m.β; new_re_levels)
 end


### PR DESCRIPTION
Thanks for contributing!

Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

No behavioral changes, but we updated a docstring enough that a patch release might be worthwhile.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately


@kliegl is the new explanation clearer? 