### PR TITLE
Efficiency improvements in `predict`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.6.2 Release Notes
+========================
+* Efficiency improvements in `predict`, both in memory and computation [#604]
+
 MixedModels v4.6.1 Release Notes
 ========================
 * Loosen type restriction on `shortestcovint(::MixedModelBootstrap)` to `shortestcovint(::MixedModelFitCollection)`. [#598]
@@ -327,3 +331,4 @@ Package dependencies
 [#578]: https://github.com/JuliaStats/MixedModels.jl/issues/578
 [#588]: https://github.com/JuliaStats/MixedModels.jl/issues/588
 [#598]: https://github.com/JuliaStats/MixedModels.jl/issues/598
+[#604]: https://github.com/JuliaStats/MixedModels.jl/issues/604

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.6.1"
+version = "4.6.2"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -113,10 +113,10 @@ function _predict(m::MixedModel{T}, newdata, β; new_re_levels) where {T}
     # number of levels and that number may not be the same for the
     # new data, we need to permute the reterms from both models to be
     # in the same order
-    newreperm = sort(1:length(mnew.reterms); by=x -> string(mnew.reterms[x].trm))
-    oldreperm = sort(1:length(m.reterms); by=x -> string(m.reterms[x].trm))
-    newre = mnew.reterms[newreperm]
-    oldre = m.reterms[oldreperm]
+    newreperm = sortperm(mnew.reterms; by=x -> string(x.trm))
+    oldreperm = sortperm(m.reterms; by=x -> string(x.trm))
+    newre = view(mnew.reterms, newreperm)
+    oldre = view(m.reterms, oldreperm)
 
     if new_re_levels == :error
         for (grp, known_levels, data_levels) in
@@ -130,7 +130,7 @@ function _predict(m::MixedModel{T}, newdata, β; new_re_levels) where {T}
         # grouping variable because we are in the :error branch
         blups = ranef(m)[oldreperm]
     elseif new_re_levels == :population
-        blups = ranef(mnew)[newreperm]
+        blups = [Matrix{T}(undef, size(t.z, 1), nlevs(t)) for t in view(mnew.reterms, newreperm)]
         blupsold = ranef(m)[oldreperm]
 
         for (idx, B) in enumerate(blups)
@@ -146,10 +146,7 @@ function _predict(m::MixedModel{T}, newdata, β; new_re_levels) where {T}
             end
         end
     elseif new_re_levels == :missing
-        # we can't quite use ranef! because we need
-        # Union{T, Missing} and not just T
-        blups = Vector{Matrix{Union{T,Missing}}}(undef, length(m.reterms))
-        copyto!(blups, ranef(mnew)[newreperm])
+        blups = [Matrix{Union{T, Missing}}(undef, size(t.z, 1), nlevs(t)) for t in view(mnew.reterms, newreperm)]
         blupsold = ranef(m)[oldreperm]
         for (idx, B) in enumerate(blups)
             oldlevels = levels(oldre[idx])

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -130,7 +130,9 @@ function _predict(m::MixedModel{T}, newdata, β; new_re_levels) where {T}
         # grouping variable because we are in the :error branch
         blups = ranef(m)[oldreperm]
     elseif new_re_levels == :population
-        blups = [Matrix{T}(undef, size(t.z, 1), nlevs(t)) for t in view(mnew.reterms, newreperm)]
+        blups = [
+            Matrix{T}(undef, size(t.z, 1), nlevs(t)) for t in view(mnew.reterms, newreperm)
+        ]
         blupsold = ranef(m)[oldreperm]
 
         for (idx, B) in enumerate(blups)
@@ -146,7 +148,10 @@ function _predict(m::MixedModel{T}, newdata, β; new_re_levels) where {T}
             end
         end
     elseif new_re_levels == :missing
-        blups = [Matrix{Union{T, Missing}}(undef, size(t.z, 1), nlevs(t)) for t in view(mnew.reterms, newreperm)]
+        blups = [
+            Matrix{Union{T,Missing}}(undef, size(t.z, 1), nlevs(t)) for
+            t in view(mnew.reterms, newreperm)
+        ]
         blupsold = ranef(m)[oldreperm]
         for (idx, B) in enumerate(blups)
             oldlevels = levels(oldre[idx])


### PR DESCRIPTION
Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately


There are a couple of improvements here:
- using `sortperm` directly instead of faking it with `sort(::Range)`
- views
- skip actually computing the BLUPs for the hidden new model. They're nonsensical, the computation can fail because the new model hasn't actually been fit, and they'll be overwritten by the relevant entries from the old model.

There will be a merge conflict with #603 for NEWS.md, but I'll sort that out after the first of this is merged.