### PR TITLE
attempt rescaling of poorly scaled problems

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+MixedModels v4.6.5 Release Notes
+========================
+* Attempt recovery when the initial parameter values lead to an invalid covariance matrix by rescaling [#615]
+* Return `finitial` when the optimizer drifts into a portion of the parameter space that yields a (numerically) invalid covariance matrix [#615]
+
+
 MixedModels v4.6.4 Release Notes
 ========================
 * Support transformed responses in `predict` [#614]
@@ -347,3 +353,4 @@ Package dependencies
 [#604]: https://github.com/JuliaStats/MixedModels.jl/issues/604
 [#608]: https://github.com/JuliaStats/MixedModels.jl/issues/608
 [#614]: https://github.com/JuliaStats/MixedModels.jl/issues/614
+[#615]: https://github.com/JuliaStats/MixedModels.jl/issues/615

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.6.4"
+version = "4.6.5"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -464,7 +464,8 @@ function fit!(
                     that is not well supported by the data and/or a poorly scaled model.
                 """
 
-        optsum.initial ./= (isempty(m.sqrtwts) ? 1.0 : maximum(m.sqrtwts)^2) *
+        optsum.initial ./=
+            (isempty(m.sqrtwts) ? 1.0 : maximum(m.sqrtwts)^2) *
             maximum(response(m))
         optsum.finitial = obj(optsum.initial, T[])
     end

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -461,8 +461,8 @@ function fit!(
         # give it one more try with a massive change in scaling
         @info "Initial step failed, rescaling initial guess and trying again."
         @warn """Failure of the initial step is often indicative of a model specification
-                    that is not well supported by the data and/or a poorly scaled model.
-                """
+                 that is not well supported by the data and/or a poorly scaled model.
+              """
         optsum.initial ./=
             (isempty(m.sqrtwts) ? 1.0 : maximum(m.sqrtwts)^2) *
             maximum(response(m))

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -445,7 +445,8 @@ function fit!(
     NLopt.min_objective!(opt, obj)
     try
         optsum.finitial = obj(optsum.initial, T[])
-    catch PosDefException
+    catch ex
+        ex isa PosDefException || rethrow()
         if all(==(first(m.y)), m.y)
             throw(
                 ArgumentError("The response is constant and thus model fitting has failed")

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -463,7 +463,6 @@ function fit!(
         @warn """Failure of the initial step is often indicative of a model specification
                     that is not well supported by the data and/or a poorly scaled model.
                 """
-
         optsum.initial ./=
             (isempty(m.sqrtwts) ? 1.0 : maximum(m.sqrtwts)^2) *
             maximum(response(m))

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -463,7 +463,8 @@ function fit!(
         @warn """Failure of the initial step is often indicative of a model specification
                     that is not well supported by the data and/or a poorly scaled model.
                 """
-        optsum.initial ./= maximum(m.sqrtwts)^2 * maximum(response(m))
+
+        optsum.initial ./= (isempty(m.sqrtwts) ? 1.0 : maximum(m.sqrtwts)^2) * maximum(response(m))
         optsum.finitial = obj(optsum.initial, T[])
     end
     empty!(fitlog)

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -451,7 +451,13 @@ function fit!(
                 ArgumentError("The response is constant and thus model fitting has failed")
             )
         else
-            rethrow()
+            # give it one more try with a massive change in scaling
+            @info "Initial step failed, rescaling initial guess and trying again."
+            @warn """Failure of the initial step is often indicative of a model specification
+                     that is not well supported by the data and/or a poorly scaled model.
+                  """
+            optsum.initial ./= maximum(m.sqrtwts)^2 * maximum(response(m))
+            optsum.finitial = obj(optsum.initial, T[])
         end
     end
     empty!(fitlog)

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -464,7 +464,8 @@ function fit!(
                     that is not well supported by the data and/or a poorly scaled model.
                 """
 
-        optsum.initial ./= (isempty(m.sqrtwts) ? 1.0 : maximum(m.sqrtwts)^2) * maximum(response(m))
+        optsum.initial ./= (isempty(m.sqrtwts) ? 1.0 : maximum(m.sqrtwts)^2) *
+            maximum(response(m))
         optsum.finitial = obj(optsum.initial, T[])
     end
     empty!(fitlog)

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -444,6 +444,11 @@ function fit!(
         val = try
             objective(updateL!(setθ!(m, x)))
         catch ex
+            # This can happen when the optimizer drifts into an area where
+            # there isn't enough shrinkage. Why finitial? Generally, it will
+            # be the (near) worst case scenario value, so the optimizer won't
+            # view it as an optimum. Using Inf messes up the quadratic
+            # approximation in BOBYQA.
             ex isa PosDefException || rethrow()
             iter == 0 && rethrow()
             m.optsum.finitial

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -436,7 +436,13 @@ function fit!(
     fitlog = optsum.fitlog
     function obj(x, g)
         isempty(g) || throw(ArgumentError("g should be empty for this objective"))
-        val = objective(updateL!(setθ!(m, x)))
+        val = try
+            objective(updateL!(setθ!(m, x)))
+        catch ex
+            ex isa PosDefException || rethrow()
+            iter == 1 && rethrow()
+            m.optsum.finitial
+        end
         iszero(rem(iter, thin)) && push!(fitlog, (copy(x), val))
         progress && ProgressMeter.next!(prog; showvalues=[(:objective, val)])
         iter += 1

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -610,12 +610,13 @@ end
     model = fit(MixedModel,
                 @formula(reaction ~ 1 + days + zerocorr(1+fulldummy(days)|subj)),
                 MixedModels.dataset(:sleepstudy);
+                progress=false,
                 contrasts=Dict(:days => HelmertCoding(),
                                :subj => Grouping()))
     fm1 = MixedModels.unfit!(deepcopy(model))
-    fm1.optsum.initial .*= 1e7
+    fm1.optsum.initial .*= 1e8
     @test_logs (:info, r"Initial step failed") (:warn, r"Failure of the initial step") fit!(fm1; progress=false)
-    @test objective(fm1) ≈ objective(model) atol=0.1
+    @test objective(fm1) ≈ objective(model) rtol=0.1
     # it would be great to test the handling of PosDefException after the first iteration
     # but this is surprisingly hard to trigger in a reliable way across platforms
     # just because of the vagaries of floating point.

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -608,7 +608,7 @@ end
 
 @testset "recovery from misscaling" begin
     fm1 = MixedModels.unfit!(deepcopy(last(models(:insteval))))
-    fm1.optsum.initial .*= 1e9
+    fm1.optsum.initial .*= 1.5e6
     @test_logs (:info, r"Initial step failed") (:warn, r"Failure of the initial step") fit!(fm1; progress=false)
     @test objective(fm1) ≈ objective(last(models(:insteval)))
     # it would be great to test the handling of PosDefException after the first iteration

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -608,7 +608,7 @@ end
 
 @testset "recovery from misscaling" begin
     fm1 = MixedModels.unfit!(deepcopy(last(models(:insteval))))
-    fm1.optsum.initial .*= 1e6
+    fm1.optsum.initial .*= 1e9
     @test_logs (:info, r"Initial step failed") (:warn, r"Failure of the initial step") fit!(fm1; progress=false)
     @test objective(fm1) ≈ objective(last(models(:insteval)))
     # it would be great to test the handling of PosDefException after the first iteration

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -605,3 +605,10 @@ end
     # that we're starting to support a non trivial type hierarchy
     @test typeof(re) == Vector{AbstractReMat{Float64}}
 end
+
+@testset "recovery from misscaling" begin
+    fm1 = MixedModels.unfit!(deepcopy(last(models(:insteval))))
+    fm1.optsum.initial .*= 1e6
+    @test_logs (:info, r"Initial step failed") (:warn, r"Failure of the initial step") fit!(fm1; progress=false)
+    @test objective(fm1) ≈ objective(last(models(:insteval)))
+end

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -611,4 +611,7 @@ end
     fm1.optsum.initial .*= 1e6
     @test_logs (:info, r"Initial step failed") (:warn, r"Failure of the initial step") fit!(fm1; progress=false)
     @test objective(fm1) ≈ objective(last(models(:insteval)))
+    # it would be great to test the handling of PosDefException after the first iteration
+    # but this is surprisingly hard to trigger in a reliable way across platforms
+    # just because of the vagaries of floating point.
 end


### PR DESCRIPTION
Closes #611

This should help address some problematic models. The basic idea is to rescale the initial identity scaling by dividing by a large number, where "large" is the product of the largest weight by the largest response value. In other words, for poorly constrained problems, we change the initial guess to already have a good amount of shrinkage and see if that helps.

I tried more naive ways of rescaling the weights or even standardizing all variables in the model, but that didn't help. @dmbates if you're happy with this solution, I can add tests and updatee NEWs, etc., but I have rather mixed feelings about it myself.

- [x] add tests
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.
- [x] I've bumped the version appropriately
