### PR TITLE
loosen type restriction on filename for optsum serialization and rename arg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.7.0 Release Notes
+==============================
+* Relax type restriction for filename in `saveoptsum` and `restoreoptsum!`. Users can now pass any type with an appropriate `open` method, e.g. `<:AbstractPath`. [#628]
+
 MixedModels v4.6.5 Release Notes
 ========================
 * Attempt recovery when the initial parameter values lead to an invalid covariance matrix by rescaling [#615]
@@ -354,3 +358,4 @@ Package dependencies
 [#608]: https://github.com/JuliaStats/MixedModels.jl/issues/608
 [#614]: https://github.com/JuliaStats/MixedModels.jl/issues/614
 [#615]: https://github.com/JuliaStats/MixedModels.jl/issues/615
+[#628]: https://github.com/JuliaStats/MixedModels.jl/issues/628

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.6.5"
+version = "4.7.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -40,7 +40,7 @@ function restoreoptsum!(m::LinearMixedModel{T}, io::IO) where {T}
     return m
 end
 
-function restoreoptsum!(m::LinearMixedModel, filename)
+function restoreoptsum!(m::LinearMixedModel{T}, filename) where {T}
     open(filename, "r") do io
         restoreoptsum!(m, io)
     end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -1,6 +1,6 @@
 """
     restoreoptsum!(m::LinearMixedModel, io::IO)
-    restoreoptsum!(m::LinearMixedModel, fnm::AbstractString)
+    restoreoptsum!(m::LinearMixedModel, filename)
 
 Read, check, and restore the `optsum` field from a JSON stream or filename.
 """
@@ -40,15 +40,15 @@ function restoreoptsum!(m::LinearMixedModel{T}, io::IO) where {T}
     return m
 end
 
-function restoreoptsum!(m::LinearMixedModel, fnm::AbstractString)
-    open(fnm, "r") do io
+function restoreoptsum!(m::LinearMixedModel, filename)
+    open(filename, "r") do io
         restoreoptsum!(m, io)
     end
 end
 
 """
     saveoptsum(io::IO, m::LinearMixedModel)
-    saveoptsum(fnm::AbstractString, m::LinearMixedModel)
+    saveoptsum(filename, m::LinearMixedModel)
 
 Save `m.optsum` (w/o the `lowerbd` field) in JSON format to an IO stream or a file
 
@@ -56,8 +56,8 @@ The reason for omitting the `lowerbd` field is because it often contains `-Inf`
 values that are not allowed in JSON.
 """
 saveoptsum(io::IO, m::LinearMixedModel) = JSON3.write(io, m.optsum)
-function saveoptsum(fnm::AbstractString, m::LinearMixedModel)
-    open(fnm, "w") do io
+function saveoptsum(filename, m::LinearMixedModel)
+    open(filename, "w") do io
         saveoptsum(io, m)
     end
 end


### PR DESCRIPTION
The loosening of the type restriction on the filename-based methods for `saveoptsum` and `restoreoptsum!` means that users can pass anytype for which `open` is defined, e.g. `<:AbstractPath`. 


Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately
