### PR TITLE
Extend rankUpdate! method to allow for upper tri

### DIFF
--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -21,7 +21,7 @@ using StructTypes
 using Tables
 
 using LinearAlgebra: BlasFloat, BlasReal, HermOrSym, PosDefException, copytri!
-using Base: Ryu
+using Base: Ryu, require_one_based_indexing
 using GLM: Link, canonicallink, linkfun, linkinv
 using StatsModels: TableRegressionModel
 

--- a/src/linalg/cholUnblocked.jl
+++ b/src/linalg/cholUnblocked.jl
@@ -11,7 +11,7 @@ function cholUnblocked! end
 function cholUnblocked!(D::Diagonal{T}, ::Type{Val{:L}}) where {T<:AbstractFloat}
     Ddiag = D.diag
     @inbounds for i in eachindex(Ddiag)
-        (ddi = Ddiag[i]) ≤ zero(T) && throw(LinearAlgebra.PosDefException(i))
+        (ddi = Ddiag[i]) ≤ zero(T) && throw(PosDefException(i))
         Ddiag[i] = sqrt(ddi)
     end
 
@@ -21,17 +21,17 @@ end
 function cholUnblocked!(A::StridedMatrix{T}, ::Type{Val{:L}}) where {T<:BlasFloat}
     n = LinearAlgebra.checksquare(A)
     if n == 1
-        A[1] < zero(T) && throw(LinearAlgebra.PosDefException(1))
+        A[1] < zero(T) && throw(PosDefException(1))
         A[1] = sqrt(A[1])
     elseif n == 2
-        A[1] < zero(T) && throw(LinearAlgebra.PosDefException(1))
+        A[1] < zero(T) && throw(PosDefException(1))
         A[1] = sqrt(A[1])
         A[2] /= A[1]
-        (A[4] -= abs2(A[2])) < zero(T) && throw(LinearAlgebra.PosDefException(2))
+        (A[4] -= abs2(A[2])) < zero(T) && throw(PosDefException(2))
         A[4] = sqrt(A[4])
     else
         _, info = LAPACK.potrf!('L', A)
-        iszero(info) || throw(LinearAlgebra.PosDefException(info))
+        iszero(info) || throw(PosDefException(info))
     end
     return A
 end

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -3,7 +3,7 @@
     rankUpdate!(C, A, α)
     rankUpdate!(C, A, α, β)
 
-A rank-k update, C := β*C + α*A'A, of a Hermitian (Symmetric) matrix.
+A rank-k update, C := α*A'A + β*C, of a Hermitian (Symmetric) matrix.
 
 `α` and `β` both default to 1.0.  When `α` is -1.0 this is a downdate operation.
 The name `rankUpdate!` is borrowed from [https://github.com/andreasnoack/LinearAlgebra.jl]
@@ -17,8 +17,9 @@ function rankUpdate!(C::AbstractMatrix, a::AbstractArray, α, β)
 end
 
 function rankUpdate!(C::HermOrSym{T,S}, a::StridedVector{T}, α, β) where {T,S}
-    isone(β) || throw(ArgumentError("isone(β) is false"))
-    BLAS.syr!(C.uplo, T(α), a, C.data)
+    Cd = C.data
+    isone(β) || rmul!(C.uplo == 'L' ? LowerTriangular(Cd) : UpperTriangular(Cd), β)
+    BLAS.syr!(C.uplo, T(α), a, Cd)
     return C  ## to ensure that the return value is HermOrSym
 end
 
@@ -30,7 +31,7 @@ end
 """
     _columndot(rv, nz, rngi, rngj)
 
-Return the dot product of columns `i` and `j` of the sparse matrix `A`
+Return the dot product of two columns, with `nzrange`s `rngi` and `rngj`, of a sparse matrix defined by rowvals `rv` and nonzeros `nz`
 """
 function _columndot(rv, nz, rngi, rngj)
     accum = zero(eltype(nz))
@@ -53,13 +54,13 @@ function _columndot(rv, nz, rngi, rngj)
 end
 
 function rankUpdate!(C::HermOrSym{T,S}, A::SparseMatrixCSC{T}, α, β) where {T,S}
-    Base.require_one_based_indexing(C, A)
+    require_one_based_indexing(C, A)
     m, n = size(A)
     Cd, rv, nz = C.data, A.rowval, A.nzval
     lower = C.uplo == 'L'
     (lower ? m : n) == size(C, 2) || throw(DimensionMismatch())
+    isone(β) || rmul!(lower ? LowerTriangular(Cd) : UpperTriangular(Cd), β)
     if lower
-        isone(β) || rmul!(LowerTriangular(Cd), β)
         @inbounds for jj in axes(A, 2)
             rangejj = nzrange(A, jj)
             lenrngjj = length(rangejj)
@@ -73,7 +74,6 @@ function rankUpdate!(C::HermOrSym{T,S}, A::SparseMatrixCSC{T}, α, β) where {T,
             end
         end
     else
-        isone(β) || rmul!(UpperTriangular(Cd), β)
         @inbounds for j in axes(C, 2)
             rngj = nzrange(A, j)
             for i in 1:(j - 1)
@@ -93,11 +93,12 @@ function rankUpdate!(
     C::HermOrSym{T,Diagonal{T,Vector{T}}}, A::StridedMatrix{T}, α, β
 ) where {T,S}
     Cdiag = C.data.diag
-    @. Cdiag = β * Cdiag
+    require_one_based_indexing(Cdiag, A)
+    length(Cdiag) == size(A, 1) || throw(DimensionMismatch())
+    isone(β) || rmul!(Cdiag, β)
 
-    for i in 1:length(Cdiag)
-        Arow = view(A, i, :)
-        Cdiag[i] = Cdiag[i] + α * Arow'Arow
+    @inbounds for i in eachindex(Cdiag)
+        Cdiag[i] += α * sum(abs2, view(A, i, :))
     end
 
     return C
@@ -107,18 +108,19 @@ function rankUpdate!(
     C::HermOrSym{T,UniformBlockDiagonal{T}}, A::StridedMatrix{T}, α, β
 ) where {T,S}
     Cdat = C.data.data
-    isone(β) || (Cdat .*= β)
+    require_one_based_indexing(Cdat, A)
+    isone(β) || rmul!(Cdat, β)
     blksize = size(Cdat, 1)
 
     for k in axes(Cdat, 3)
         ioffset = (k - 1) * blksize
         joffset = (k - 1) * blksize
-        for i in 1:blksize, j in 1:i
+        for i in axes(Cdat, 1), j in 1:i
             iind = ioffset + i
             jind = joffset + j
             AtAij = 0
             for idx in axes(A, 2)
-                # because the second is actually A', we swap index orders
+                # because the second multiplicant is from A', swap index order
                 AtAij += A[iind, idx] * A[jind, idx]
             end
             Cdat[i, j, k] += α * AtAij
@@ -132,13 +134,16 @@ function rankUpdate!(
     C::HermOrSym{T,Diagonal{T,Vector{T}}}, A::SparseMatrixCSC{T}, α, β
 ) where {T}
     dd = C.data.diag
+    require_one_based_indexing(dd, A)
     A.m == length(dd) || throw(DimensionMismatch())
     isone(β) || rmul!(dd, β)
     all(isone.(diff(A.colptr))) ||
         throw(ArgumentError("Columns of A must have exactly 1 nonzero"))
+
     for (r, nz) in zip(rowvals(A), nonzeros(A))
         dd[r] += α * abs2(nz)
     end
+
     return C
 end
 
@@ -151,37 +156,21 @@ function rankUpdate!(
 ) where {T,S}
     Ac = A.cscmat
     cp = Ac.colptr
-    all(diff(cp) .== S) ||
+    all(==(S), diff(cp)) ||
         throw(ArgumentError("Columns of A must have exactly $S nonzeros"))
     Cdat = C.data.data
+    require_one_based_indexing(Ac, Cdat)
+
     j, k, l = size(Cdat)
     S == j == k && div(Ac.m, S) == l ||
         throw(DimensionMismatch("div(A.cscmat.m, S) ≠ size(C.data.data, 3)"))
     nz = Ac.nzval
     rv = Ac.rowval
-    for j in 1:(Ac.n)
+
+    @inbounds for j in axes(Ac, 2)
         nzr = nzrange(Ac, j)
         BLAS.syr!('L', α, view(nz, nzr), view(Cdat, :, :, div(rv[last(nzr)], S)))
     end
+
     return C
 end
-#=  I don't think Diagonal A can occur after the terms with the same grouping factor have been amalgamated.
-function rankUpdate!(C::HermOrSym{T,Diagonal{T}}, A::Diagonal{T}, α, β) where {T}
-    Cdiag = C.data.diag
-    if length(Cdiag) ≠ length(A.diag)
-        throw(DimensionMismatch("length(C.data.diag) ≠ length(A.diag)"))
-    end
-
-    Cdiag .= β .* Cdiag .+ α .* abs2.(A.diag)
-    C
-end
-
-function rankUpdate!(C::HermOrSym{T,Matrix{T}}, A::Diagonal{T}, α, β) where {T}
-    Adiag, Cdata = A.diag, C.data
-    length(Adiag) == size(C, 2) || throw(DimensionMismatch())
-    for (i, a) in zip(diagind(Cdata), Adiag)
-        Cdata[i] = β * Cdata[i] + α * abs2(a)
-    end
-    C
-end
-=#

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -58,7 +58,7 @@ end
     # in < 1.6, typeof(x) == Array{Int64, 2}
     err = ErrorException("We haven't implemented a method for $(typeof(x)), $(typeof(x)). Please file an issue on GitHub.");
     @test_throws ErrorException rankUpdate!(x, x, 1, 1);
-    L21 = sprand(Xoshiro(42), 100, 1000, 0.05)
+    L21 = sprand(MersenneTwister(42), 100, 1000, 0.05)
     L22L = rankUpdate!(Symmetric(zeros(100, 100), :L), L21, 1.0, 1.0)
     @test L22L ≈ rankUpdate!(Symmetric(zeros(100, 100), :U), sparse(transpose(L21)), 1.0, 1.0)
 end

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -58,6 +58,9 @@ end
     # in < 1.6, typeof(x) == Array{Int64, 2}
     err = ErrorException("We haven't implemented a method for $(typeof(x)), $(typeof(x)). Please file an issue on GitHub.");
     @test_throws ErrorException rankUpdate!(x, x, 1, 1);
+    L21 = sprand(Xoshiro(42), 100, 1000, 0.05)
+    L22L = rankUpdate!(Symmetric(zeros(100, 100), :L), L21, 1.0, 1.0)
+    @test L22L ≈ rankUpdate!(Symmetric(zeros(100, 100), :U), sparse(transpose(L21)), 1.0, 1.0)
 end
 
 #=  I don't see this testset as meaningful b/c diagonal A does not occur after amalgamation of ReMat's for the same grouping factor - D.B.


### PR DESCRIPTION
- Add checks of `require_one_based_indexing` and macro calls `@inbounds` in some files in the `linalg` directory

- Add more checks for positive definiteness in `cholUnblocked.jl`.

- Although this commit allows for `rankUpdate!` of the upper triangle it turns out that this is much slower than updating the lower triangle.

```julia
julia> using BenchmarkTools, LinearAlgebra, MixedModels
[ Info: Precompiling MixedModels [ff71e718-51f3-5ec2-a782-8ffcbfa3c316]

julia> const contrasts = Dict{Symbol,Any}(:subj => Grouping(), :s => Grouping(), :d => Grouping(), :dept => Grouping(), :service => EffectsCoding());

julia> const form = @formula(y ~ 1 + service + (1|s) + (1|d) + (1|dept));

julia> insteval = MixedModels.dataset(:insteval);

julia> iem01 = fit(MixedModel, form, insteval; contrasts)
Minimizing 115 	 Time: 0:00:01 (16.15 ms/it)
Linear mixed model fit by maximum likelihood
 y ~ 1 + service + (1 | s) + (1 | d) + (1 | dept)
    logLik     -2 logLik       AIC         AICc          BIC     
 -118860.8844  237721.7688  237733.7688  237733.7699  237788.9926

Variance components:
            Column    Variance  Std.Dev. 
s        (Intercept)  0.1059724 0.3255340
d        (Intercept)  0.2652055 0.5149811
dept     (Intercept)  0.0061676 0.0785341
Residual              1.3864886 1.1774925
 Number of obs: 73421; levels of grouping factors: 2972, 1128, 14

  Fixed-effects parameters:
─────────────────────────────────────────────────────
                  Coef.  Std. Error       z  Pr(>|z|)
─────────────────────────────────────────────────────
(Intercept)   3.23629    0.0281513   114.96    <1e-99
service: Y   -0.0462943  0.00669159   -6.92    <1e-11
─────────────────────────────────────────────────────

julia> @time fit(MixedModel, form, insteval; contrasts);
Minimizing 115 	 Time: 0:00:00 ( 8.68 ms/it)
  1.082987 seconds (310.67 k allocations: 52.726 MiB, 2.81% gc time)

julia> const C = zeros(1128, 1128);

julia> const A = iem01.L[2];

julia> @benchmark MixedModels.rankUpdate!(CC, AA, 1.0, 1.0) setup=(CC=Symmetric(fill!(C, 0.0), :L); AA=A)
BenchmarkTools.Trial: 2676 samples with 1 evaluation.
 Range (min … max):  1.583 ms …  2.572 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.621 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.629 ms ± 42.664 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▃▃▄▄▇▇█▆▄▄▂                                           
  ▁▁▂▃▄████████████▇▇▅▅▅▅▄▄▃▃▃▃▃▂▂▂▂▂▂▂▂▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  1.58 ms        Histogram: frequency by time        1.75 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark MixedModels.rankUpdate!(CC, AA, 1.0, 1.0) setup=(CC=Symmetric(fill!(C, 0.0), :U); AA=sparse(transpose(A)))
BenchmarkTools.Trial: 26 samples with 1 evaluation.
 Range (min … max):  193.801 ms … 194.178 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     194.037 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   194.027 ms ± 100.684 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▁   ▁▁                   ▁ ███ ▁  ▁▁    ▁▁█ ▁ ▁  ▁█    ▁  █ ▁  
  █▁▁▁██▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█▁███▁█▁▁██▁▁▁▁███▁█▁█▁▁██▁▁▁▁█▁▁█▁█ ▁
  194 ms           Histogram: frequency by time          194 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```
