### PR TITLE
Avoid repeating first objective evaluation in fit!

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+MixedModels v4.7.1 Release Notes
+==============================
+* Avoid repeating initial objective evaluation in `fit!` method for `LinearMixedModel`
+* Ensure that the number of function evaluations from NLopt corresponds to `length(m.optsum.fitlog) when `isone(thin)`.
+
 MixedModels v4.7.0 Release Notes
 ==============================
 * Relax type restriction for filename in `saveoptsum` and `restoreoptsum!`. Users can now pass any type with an appropriate `open` method, e.g. `<:AbstractPath`. [#628]

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 MixedModels v4.7.1 Release Notes
 ==============================
 * Avoid repeating initial objective evaluation in `fit!` method for `LinearMixedModel`
-* Ensure that the number of function evaluations from NLopt corresponds to `length(m.optsum.fitlog) when `isone(thin)`.
+* Ensure that the number of function evaluations from NLopt corresponds to `length(m.optsum.fitlog) when `isone(thin)`. [#637]
 
 MixedModels v4.7.0 Release Notes
 ==============================
@@ -364,3 +364,4 @@ Package dependencies
 [#614]: https://github.com/JuliaStats/MixedModels.jl/issues/614
 [#615]: https://github.com/JuliaStats/MixedModels.jl/issues/615
 [#628]: https://github.com/JuliaStats/MixedModels.jl/issues/628
+[#637]: https://github.com/JuliaStats/MixedModels.jl/issues/637

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.7.0"
+version = "4.7.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -441,37 +441,41 @@ function fit!(
     fitlog = optsum.fitlog
     function obj(x, g)
         isempty(g) || throw(ArgumentError("g should be empty for this objective"))
-        val = try
-            objective(updateL!(setθ!(m, x)))
-        catch ex
+        iter += 1
+        val = if isone(iter) && x == optsum.initial
+            optsum.finitial
+        else
+            try
+                objective(updateL!(setθ!(m, x)))
+            catch ex
             # This can happen when the optimizer drifts into an area where
             # there isn't enough shrinkage. Why finitial? Generally, it will
             # be the (near) worst case scenario value, so the optimizer won't
             # view it as an optimum. Using Inf messes up the quadratic
             # approximation in BOBYQA.
-            ex isa PosDefException || rethrow()
-            iter == 0 && rethrow()
-            m.optsum.finitial
+                ex isa PosDefException || rethrow()
+                optsum.finitial
+            end
         end
-        iszero(rem(iter, thin)) && push!(fitlog, (copy(x), val))
         progress && ProgressMeter.next!(prog; showvalues=[(:objective, val)])
-        iter += 1
+        !isone(iter) && iszero(rem(iter, thin)) && push!(fitlog, (copy(x), val))
         return val
     end
     NLopt.min_objective!(opt, obj)
     try
-        optsum.finitial = obj(optsum.initial, T[])
+        # use explicit evaluation w/o calling opt to avoid confusing iteration count
+        optsum.finitial = objective(updateL!(setθ!(m, optsum.initial)))
     catch ex
         ex isa PosDefException || rethrow()
         # give it one more try with a massive change in scaling
-        @info "Initial step failed, rescaling initial guess and trying again."
-        @warn """Failure of the initial step is often indicative of a model specification
+        @info "Initial objective evaluation failed, rescaling initial guess and trying again."
+        @warn """Failure of the initial evaluation is often indicative of a model specification
                  that is not well supported by the data and/or a poorly scaled model.
               """
         optsum.initial ./=
             (isempty(m.sqrtwts) ? 1.0 : maximum(m.sqrtwts)^2) *
             maximum(response(m))
-        optsum.finitial = obj(optsum.initial, T[])
+        optsum.finitial = objective(updateL!(setθ!(m, optsum.initial)))
     end
     empty!(fitlog)
     push!(fitlog, (copy(optsum.initial), optsum.finitial))

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -448,11 +448,11 @@ function fit!(
             try
                 objective(updateL!(setθ!(m, x)))
             catch ex
-            # This can happen when the optimizer drifts into an area where
-            # there isn't enough shrinkage. Why finitial? Generally, it will
-            # be the (near) worst case scenario value, so the optimizer won't
-            # view it as an optimum. Using Inf messes up the quadratic
-            # approximation in BOBYQA.
+                # This can happen when the optimizer drifts into an area where
+                # there isn't enough shrinkage. Why finitial? Generally, it will
+                # be the (near) worst case scenario value, so the optimizer won't
+                # view it as an optimum. Using Inf messes up the quadratic
+                # approximation in BOBYQA.
                 ex isa PosDefException || rethrow()
                 optsum.finitial
             end

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -615,7 +615,7 @@ end
                                :subj => Grouping()))
     fm1 = MixedModels.unfit!(deepcopy(model))
     fm1.optsum.initial .*= 1e8
-    @test_logs (:info, r"Initial step failed") (:warn, r"Failure of the initial step") fit!(fm1; progress=false)
+    @test_logs (:info, r"Initial objective evaluation failed") (:warn, r"Failure of the initial ") fit!(fm1; progress=false)
     @test objective(fm1) ≈ objective(model) rtol=0.1
     # it would be great to test the handling of PosDefException after the first iteration
     # but this is surprisingly hard to trigger in a reliable way across platforms


### PR DESCRIPTION
- Modify the `obj` function in `fit!` for a `LinearMixedModel` to return the previously calculated `optsum.finitial` when `isone(iter += 1)`

Did behavior change? Did you add new features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately
