### PR TITLE
Combine updateL! operations on diagonal blocks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.7.2 Release Notes
+==============================
+* Replace separate calls to `copyto!` and `scaleinflate!` in `updateL!` with `copyscaleinflate!` [#648]
+
 MixedModels v4.7.1 Release Notes
 ==============================
 * Avoid repeating initial objective evaluation in `fit!` method for `LinearMixedModel`
@@ -365,3 +369,4 @@ Package dependencies
 [#615]: https://github.com/JuliaStats/MixedModels.jl/issues/615
 [#628]: https://github.com/JuliaStats/MixedModels.jl/issues/628
 [#637]: https://github.com/JuliaStats/MixedModels.jl/issues/637
+[#648]: https://github.com/JuliaStats/MixedModels.jl/issues/648

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.7.1"
+version = "4.7.2"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/arraytypes.jl
+++ b/src/arraytypes.jl
@@ -12,14 +12,6 @@ function Base.axes(A::UniformBlockDiagonal)
     return (Base.OneTo(m * l), Base.OneTo(n * l))
 end
 
-function Base.copyto!(dest::UniformBlockDiagonal{T}, src::UniformBlockDiagonal{T}) where {T}
-    sdat = src.data
-    ddat = dest.data
-    size(ddat) == size(sdat) || throw(DimensionMismatch(""))
-    copyto!(ddat, sdat)
-    return dest
-end
-
 function Base.copyto!(dest::Matrix{T}, src::UniformBlockDiagonal{T}) where {T}
     size(dest) == size(src) || throw(DimensionMismatch(""))
     fill!(dest, zero(T))

--- a/src/precompile_MixedModels.jl
+++ b/src/precompile_MixedModels.jl
@@ -24,7 +24,7 @@ end   # time: 2.1690955
     Base.precompile(Tuple{typeof(adjA),Vector{Int32},Matrix{Float64}})   # time: 0.11642844
     Base.precompile(Tuple{typeof(apply_schema),Term,MultiSchema{FullRank},UnionAll})   # time: 0.0992202
     Base.precompile(Tuple{typeof(fit),Type{GeneralizedLinearMixedModel},FormulaTerm,NamedTuple,Bernoulli,LogitLink})   # time: 0.09839547
-    Base.precompile(Tuple{typeof(scaleinflate!),UniformBlockDiagonal{Float64},ReMat{Float64, 2}})   # time: 0.07856259
+    Base.precompile(Tuple{typeof(copyscaleinflate!),UniformBlockDiagonal{Float64},UniformBlockDiagonal{Float64},ReMat{Float64, 2}})   # time: 0.07856259
     Base.precompile(Tuple{typeof(*),Adjoint{Float64, ReMat{Float64, 2}},ReMat{Float64, 2}})   # time: 0.064247385
     let fbody = try Base.bodyfunction(which(fit, (Type{LinearMixedModel},FormulaTerm,NamedTuple,))) catch missing end
     if !ismissing(fbody)
@@ -38,7 +38,7 @@ end   # time: 0.0641711
     Base.precompile(Tuple{typeof(LD),UniformBlockDiagonal{Float64}})   # time: 0.029826526
     Base.precompile(Tuple{typeof(*),Adjoint{Float64, ReMat{Float64, 1}},ReMat{Float64, 1}})   # time: 0.02977296
     Base.precompile(Tuple{typeof(GLM.wrkresp!),SubArray{Float64, 1, Matrix{Float64}, Tuple{Base.Slice{Base.OneTo{Int64}}, Int64}, true},GLM.GlmResp{Vector{Float64}, Bernoulli{Float64}, LogitLink}})   # time: 0.022571307
-    Base.precompile(Tuple{typeof(scaleinflate!),Diagonal{Float64, Vector{Float64}},ReMat{Float64, 1}})   # time: 0.014116756
+    Base.precompile(Tuple{typeof(copyscaleinflate!),Diagonal{Float64, Vector{Float64}},Diagonal{Float64, Vector{Float64}},ReMat{Float64, 1}})   # time: 0.014116756
     Base.precompile(Tuple{typeof(cholUnblocked!),UniformBlockDiagonal{Float64},Type{Val{:L}}})   # time: 0.011265205
     Base.precompile(Tuple{Core.Type{MixedModels.GeneralizedLinearMixedModel{Float64, Distributions.Bernoulli}},LinearMixedModel,Any,Any,Vector,Any,Any,Any,Any,Any,Any,Any,Any,Any,Any})   # time: 0.010291444
     Base.precompile(Tuple{typeof(apply_schema),RandomEffectsTerm,MultiSchema{FullRank},Type{LinearMixedModel}})   # time: 0.009160354

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -572,9 +572,9 @@ function copyscaleinflate!(Ljj::Matrix{T}, Ajj::Diagonal{T}, Λj::ReMat{T,1}) wh
 end
 
 function copyscaleinflate!(
-    Ljj::UniformBlockDiagonal{T}, 
+    Ljj::UniformBlockDiagonal{T},
     Ajj::UniformBlockDiagonal{T},
-    Λj::ReMat{T,S},
+    Λj::ReMat{T,S}
 ) where {T,S}
     λ = Λj.λ
     dind = diagind(S, S)
@@ -592,7 +592,7 @@ end
 function copyscaleinflate!(
     Ljj::Matrix{T},
     Ajj::UniformBlockDiagonal{T},
-    Λj::ReMat{T,S},
+    Λj::ReMat{T,S}
 ) where {T,S}
     copyto!(Ljj, Ajj)
     n = LinearAlgebra.checksquare(Ljj)

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -550,31 +550,35 @@ function rowlengths(A::ReMat)
 end
 
 """
-    scaleinflate!(L::AbstractMatrix, Λ::ReMat)
+    copyscaleinflate!(L::AbstractMatrix, A::AbstractMatrix, Λ::ReMat)
 
-Overwrite L with `Λ'LΛ + I`
+Overwrite L with `Λ'AΛ + I`
 """
-function scaleinflate! end
+function copyscaleinflate! end
 
-function scaleinflate!(Ljj::Diagonal{T}, Λj::ReMat{T,1}) where {T}
-    Ljjd = Ljj.diag
-    broadcast!((x, λsqr) -> x * λsqr + 1, Ljjd, Ljjd, abs2(only(Λj.λ.data)))
+function copyscaleinflate!(Ljj::Diagonal{T}, Ajj::Diagonal{T}, Λj::ReMat{T,1}) where {T}
+    Ldiag, Adiag = Ljj.diag, Ajj.diag
+    broadcast!((x, λsqr) -> x * λsqr + one(T), Ldiag, Adiag, abs2(only(Λj.λ.data)))
     return Ljj
 end
 
-function scaleinflate!(Ljj::Matrix{T}, Λj::ReMat{T,1}) where {T}
+function copyscaleinflate!(Ljj::Matrix{T}, Ajj::Diagonal{T}, Λj::ReMat{T,1}) where {T}
+    fill!(Ljj, zero(T))
     lambsq = abs2(only(Λj.λ.data))
-    @inbounds for i in diagind(Ljj)
-        Ljj[i] *= lambsq
-        Ljj[i] += one(T)
+    @inbounds for (i, a) in enumerate(Ajj.diag)
+        Ljj[i, i] = lambsq * a + one(T)
     end
     return Ljj
 end
 
-function scaleinflate!(Ljj::UniformBlockDiagonal{T}, Λj::ReMat{T,S}) where {T,S}
+function copyscaleinflate!(
+    Ljj::UniformBlockDiagonal{T}, 
+    Ajj::UniformBlockDiagonal{T},
+    Λj::ReMat{T,S},
+) where {T,S}
     λ = Λj.λ
     dind = diagind(S, S)
-    Ldat = Ljj.data
+    Ldat = copyto!(Ljj.data, Ajj.data)
     for k in axes(Ldat, 3)
         f = view(Ldat, :, :, k)
         lmul!(λ', rmul!(f, λ))
@@ -585,7 +589,12 @@ function scaleinflate!(Ljj::UniformBlockDiagonal{T}, Λj::ReMat{T,S}) where {T,S
     return Ljj
 end
 
-function scaleinflate!(Ljj::Matrix{T}, Λj::ReMat{T,S}) where {T,S}
+function copyscaleinflate!(
+    Ljj::Matrix{T},
+    Ajj::UniformBlockDiagonal{T},
+    Λj::ReMat{T,S},
+) where {T,S}
+    copyto!(Ljj, Ajj)
     n = LinearAlgebra.checksquare(Ljj)
     q, r = divrem(n, S)
     iszero(r) || throw(DimensionMismatch("size(Ljj, 1) is not a multiple of S"))

--- a/test/UniformBlockDiagonal.jl
+++ b/test/UniformBlockDiagonal.jl
@@ -42,12 +42,12 @@ const LMM = LinearMixedModel
         @test view(ex22.data, :, :, 3) == reshape(9:12, (2,2))
     end
 
-    @testset "scaleinflate" begin
-        MixedModels.scaleinflate!(copyto!(Lblk, ex22), vf1)
+    @testset "copyscaleinflate" begin
+        MixedModels.copyscaleinflate!(Lblk, ex22, vf1)
         @test view(Lblk.data, :, :, 1) == [2. 3.; 2. 5.]
         setθ!(vf1, [1.,1.,1.])
         Λ = vf1.λ
-        MixedModels.scaleinflate!(copyto!(Lblk, ex22), vf1)
+        MixedModels.copyscaleinflate!(Lblk, ex22, vf1)
         target = Λ'view(ex22.data, :, :, 1)*Λ + I
         @test view(Lblk.data, :, :, 1) == target
     end
@@ -61,7 +61,7 @@ const LMM = LinearMixedModel
         @test vf1.λ == LowerTriangular(Matrix(I, 2, 2))
         setθ!(vf2, [1.75, 0.0, 1.0])
         A11 = vf1'vf1
-        L11 = MixedModels.cholUnblocked!(MixedModels.scaleinflate!(copyto!(UniformBlockDiagonal(fill(0., size(A11.data))), A11), vf1), Val{:L})
+        L11 = MixedModels.cholUnblocked!(MixedModels.copyscaleinflate!(UniformBlockDiagonal(fill(0., size(A11.data))), A11, vf1), Val{:L})
         L21 = vf2'vf1
         @test isa(L21, BlockedSparse)
         @test L21[1,1] == 30.0
@@ -74,6 +74,6 @@ const LMM = LinearMixedModel
 #        rdiv!(L21, adjoint(LowerTriangular(L11)))
 #        @test_broken L21.colblocks[1] == rdiv!(L21cb1, adjoint(LowerTriangular(L11.facevec[1])))
          A22 = vf2'vf2
-         L22 = MixedModels.scaleinflate!(copyto!(UniformBlockDiagonal(fill(0., size(A22.data))), A22), vf2)
+         L22 = MixedModels.copyscaleinflate!(UniformBlockDiagonal(fill(0., size(A22.data))), A22, vf2)
     end
 end


### PR DESCRIPTION
closes #643 

- Previously the sequence of operations in `updateL!` was to copy blocks of `A` to the corresponding block of `L` then iterate over the random effects terms scaling the diagonal block and inflating the diagonal.
- This PR combines those operations on the diagonal blocks, replacing separate calls to `copyto!` and `scaleinflate!` by `copyscaleinflate!`.
- This reduces the number of times iterating over the diagonal elements, which may help with further enhancements such as using [RectangularFullPacked](https://github.com/JuliaLinearAlgebra/RectangularFullPacked.jl) storage for triangular blocks of `L`.
- Closes #643

Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately
