### PR TITLE
don't fit a GLM when fixed effects are empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+
+
+* Don't fit a GLM internally during construction of GLMM when the fixed effects are empty (better compatibility with
+  `dropcollinear` kwarg in newer GLM.jl) [#657]
+
 MixedModels v4.8.0 Release Notes
 ==============================
 * Allow predicting from a single observation, as long as `Grouping()` is used for the grouping variables. The simplified implementation of `Grouping()` also removes several now unnecessary `StatsModels` methods that should not have been called directly by the user. [#653]
@@ -380,3 +385,4 @@ Package dependencies
 [#648]: https://github.com/JuliaStats/MixedModels.jl/issues/648
 [#651]: https://github.com/JuliaStats/MixedModels.jl/issues/651
 [#653]: https://github.com/JuliaStats/MixedModels.jl/issues/653
+[#657]: https://github.com/JuliaStats/MixedModels.jl/issues/657

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,4 +19,6 @@ makedocs(;
     ],
 )
 
-deploydocs(;repo = "github.com/JuliaStats/MixedModels.jl.git", push_preview = true, devbranch = "main")
+deploydocs(;
+    repo="github.com/JuliaStats/MixedModels.jl.git", push_preview=true, devbranch="main"
+)

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -403,8 +403,15 @@ function GeneralizedLinearMixedModel(
     constresponse || updateL!(LMM)
     # fit a glm to the fixed-effects only
     T = eltype(LMM.Xymat)
-    gl = glm(LMM.X, y, d, l; wts=convert(Vector{T}, wts), offset=convert(Vector{T}, offset))
-    β = coef(gl)
+    # newer versions of GLM (>1.8.0) have a kwarg dropcollinear=true
+    # which creates problems for the empty fixed-effects case during fitting
+    # so just don't allow fitting
+    # XXX unfortunately, this means we have double-rank defiency detection
+    # TODO: construct GLM by hand so that we skip collinearity checks
+    # TODO: extend this so that we never fit a GLM when initializing from LMM
+    dofit = size(LMM.X, 2) != 0
+    gl = glm(LMM.X, y, d, l; wts=convert(Vector{T}, wts), dofit, offset=convert(Vector{T}, offset))
+    β = dofit ? coef(gl) : T[]
     u = [fill(zero(eltype(y)), vsize(t), nlevs(t)) for t in LMM.reterms]
     # vv is a template vector used to initialize fields for AGQ
     # it is empty unless there is a single random-effects term

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -409,7 +409,7 @@ function GeneralizedLinearMixedModel(
     # XXX unfortunately, this means we have double-rank defiency detection
     # TODO: construct GLM by hand so that we skip collinearity checks
     # TODO: extend this so that we never fit a GLM when initializing from LMM
-    dofit = size(LMM.X, 2) != 0
+    dofit = size(LMM.X, 2) != 0 # GLM.jl kwarg
     gl = glm(LMM.X, y, d, l;
         wts=convert(Vector{T}, wts),
         dofit,

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -411,9 +411,9 @@ function GeneralizedLinearMixedModel(
     # TODO: extend this so that we never fit a GLM when initializing from LMM
     dofit = size(LMM.X, 2) != 0
     gl = glm(LMM.X, y, d, l;
-             wts=convert(Vector{T}, wts),
-             dofit,
-             offset=convert(Vector{T}, offset))
+        wts=convert(Vector{T}, wts),
+        dofit,
+        offset=convert(Vector{T}, offset))
     β = dofit ? coef(gl) : T[]
     u = [fill(zero(eltype(y)), vsize(t), nlevs(t)) for t in LMM.reterms]
     # vv is a template vector used to initialize fields for AGQ

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -410,7 +410,10 @@ function GeneralizedLinearMixedModel(
     # TODO: construct GLM by hand so that we skip collinearity checks
     # TODO: extend this so that we never fit a GLM when initializing from LMM
     dofit = size(LMM.X, 2) != 0
-    gl = glm(LMM.X, y, d, l; wts=convert(Vector{T}, wts), dofit, offset=convert(Vector{T}, offset))
+    gl = glm(LMM.X, y, d, l;
+             wts=convert(Vector{T}, wts),
+             dofit,
+             offset=convert(Vector{T}, offset))
     β = dofit ? coef(gl) : T[]
     u = [fill(zero(eltype(y)), vsize(t), nlevs(t)) for t in LMM.reterms]
     # vv is a template vector used to initialize fields for AGQ


### PR DESCRIPTION
Thanks for contributing!

Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? 
> No, should be bundled in #639 

If so, bump the version:
- [ ] ~I've bumped the version appropriately~ 
