### PR TITLE
patch bump

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 
-
+MixedModels v4.8.1 Release Notes
+==============================
 * Don't fit a GLM internally during construction of GLMM when the fixed effects are empty (better compatibility with
   `dropcollinear` kwarg in newer GLM.jl) [#657]
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.8.0"
+version = "4.8.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"


### PR DESCRIPTION
This is releasing a bug/compat fix for GLM.jl, which had breaking-ish behavior in its 1.8 release. This should also address why we're failing PkgEval.

Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately
