### PR TITLE
Update benchmarks, single global contrasts Dict

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,6 @@
-MixedModels v4.9.1 Release Notes
-==============================
-* Revise code in benchmarks to work with recent Julia and PkgBenchmark.jl [#667]
-
 MixedModels v4.9.0 Release Notes
 ==============================
+* Revise code in benchmarks to work with recent Julia and PkgBenchmark.jl [#667]
 * Julia minimum compat version raised to 1.8 because of BSplineKit [#665]
 
 MixedModels v4.8.2 Release Notes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.9.1 Release Notes
+==============================
+* Revise code in benchmarks to work with recent Julia and PkgBenchmark.jl [#667]
+
 MixedModels v4.9.0 Release Notes
 ==============================
 * Julia minimum compat version raised to 1.8 because of BSplineKit [#665]
@@ -396,3 +400,4 @@ Package dependencies
 [#657]: https://github.com/JuliaStats/MixedModels.jl/issues/657
 [#663]: https://github.com/JuliaStats/MixedModels.jl/issues/663
 [#665]: https://github.com/JuliaStats/MixedModels.jl/issues/665
+[#667]: https://github.com/JuliaStats/MixedModels.jl/issues/667

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -3,88 +3,112 @@ using MixedModels: dataset
 
 const SUITE = BenchmarkGroup()
 
-const global contrasts = Dict(
-    :mrk17_exp1 => merge(Dict(n => HelmertCoding() for n in (:F, :P, :Q, :lQ, :lT)), Dict(n => Grouping() for n in (:item, :subj))),
-    :kb07 => merge(Dict(n => HelmertCoding() for n in (:spkr, :prec, :load)), Dict(n => Grouping() for n in (:item, :subj))),
-    :insteval => Dict(n => Grouping() for n in (:s, :d)),
-)
-const global fms = Dict(
-    :dyestuff => [
-        @formula(yield ~ 1 + (1|batch)),
-        ],
-    :dyestuff2 => [
-        @formula(yield ~ 1 + (1|batch)),
-        ],
-    :d3 => [
-        @formula(y ~ 1 + u + (1+u|g) + (1+u|h) + (1+u|i)),
-        ],
-    :insteval => [
-        @formula(y ~ 1 + service + (1|s) + (1|d) + (1|dept)),
-        @formula(y ~ 1 + service*dept + (1|s) + (1|d)),
-        ],
-    :kb07 => [
-        @formula(rt_trunc ~ 1+spkr+prec+load+(1|subj)+(1|item)),
-        @formula(rt_trunc ~ 1+spkr*prec*load+(1|subj)+(1+prec|item)),
-        @formula(rt_trunc ~ 1+spkr*prec*load+(1+spkr+prec+load|subj)+(1+spkr+prec+load|item)),
-        ],
-    :machines => [
-        @formula(score ~ 1 + (1|Worker) + (1|Machine)),
-        ],
-    :ml1m => [
-        @formula(y ~ 1 + (1|g) + (1|h)),
-        ],
-    :mrk17_exp1 => [
-        @formula(1000/rt ~ 1+F*P*Q*lQ*lT + (1|item) + (1|subj)),
-        @formula(1000/rt ~ 1+F*P*Q*lQ*lT + (1+P+Q+lQ+lT|item) + (1+F+P+Q+lQ+lT|subj)),
-        ],
-    :pastes => [
-        @formula(strength ~ 1 + (1|batch&cask)),
-        @formula(strength ~ 1 + (1|batch/cask)),
-        ],
-    :penicillin => [
-        @formula(diameter ~ 1 + (1|plate) + (1|sample)),
-        ],
-    :sleepstudy => [
-        @formula(reaction ~ 1 + days + (1|subj)),
-        @formula(reaction ~ 1 + days + zerocorr(1+days|subj)),
-        @formula(reaction ~ 1 + days + (1|subj) + (0+days|subj)),
-        @formula(reaction ~ 1 + days + (1+days|subj)),
-        ],
+const global contrasts = Dict{Symbol,Any}(
+    :batch => Grouping(),     # dyestuff, dyestuff2, pastes
+    :cask => Grouping(),      # pastes
+    :d => Grouping(),         # insteval
+    # :dept => Grouping(),    # insteval - not set b/c also used in fixed effects
+    :g => Grouping(),         # d3, ml1m
+    :h => Grouping(),         # d3, ml1m
+    :i => Grouping(),         # d3
+    :item => Grouping(),      # kb07, mrk17_exp1,
+    :Machine => Grouping(),   # machines
+    :plate => Grouping(),     # penicillin
+    :s => Grouping(),         # insteval
+    :sample => Grouping(),    # penicillin
+    :subj => Grouping(),      # kb07, mrk17_exp1, sleepstudy
+    :Worker => Grouping(),    # machines
+    :F => HelmertCoding(),       # mrk17_exp1
+    :P => HelmertCoding(),       # mrk17_exp1
+    :Q => HelmertCoding(),       # mrk17_exp1
+    :lQ => HelmertCoding(),      # mrk17_exp1
+    :lT => HelmertCoding(),      # mrk17_exp1
+    :load => HelmertCoding(),    # kb07
+    :prec => HelmertCoding(),    # kb07
+    :service => HelmertCoding(), # insteval
+    :spkr => HelmertCoding(),    # kb07
 )
 
-function fitbobyqa(dsname::Symbol, index::Integer)
-    fit(
-        MixedModel, 
-        fms[dsname][index], 
-        dataset(dsname), 
-        contrasts=get!(contrasts, dsname, Dict{Symbol,StatsModels.AbstractContrasts}()),
-        )
+const global fms = Dict(
+    :dyestuff => [
+        @formula(yield ~ 1 + (1 | batch))
+    ],
+    :dyestuff2 => [
+        @formula(yield ~ 1 + (1 | batch))
+    ],
+    :d3 => [
+        @formula(y ~ 1 + u + (1 + u | g) + (1 + u | h) + (1 + u | i))
+    ],
+    :insteval => [
+        @formula(y ~ 1 + service + (1 | s) + (1 | d) + (1 | dept)),
+        @formula(y ~ 1 + service * dept + (1 | s) + (1 | d)),
+    ],
+    :kb07 => [
+        @formula(rt_trunc ~ 1 + spkr + prec + load + (1 | subj) + (1 | item)),
+        @formula(rt_trunc ~ 1 + spkr * prec * load + (1 | subj) + (1 + prec | item)),
+        @formula(
+            rt_trunc ~
+                1 + spkr * prec * load + (1 + spkr + prec + load | subj) +
+                (1 + spkr + prec + load | item)
+        ),
+    ],
+    :machines => [
+        @formula(score ~ 1 + (1 | Worker) + (1 | Machine))
+    ],
+    :ml1m => [
+        @formula(y ~ 1 + (1 | g) + (1 | h))
+    ],
+    :mrk17_exp1 => [
+        @formula(1000 / rt ~ 1 + F * P * Q * lQ * lT + (1 | item) + (1 | subj)),
+        @formula(
+            1000 / rt ~
+                1 + F * P * Q * lQ * lT + (1 + P + Q + lQ + lT | item) +
+                (1 + F + P + Q + lQ + lT | subj)
+        ),
+    ],
+    :pastes => [
+        @formula(strength ~ 1 + (1 | batch & cask)),
+        @formula(strength ~ 1 + (1 | batch / cask)),
+    ],
+    :penicillin => [
+        @formula(diameter ~ 1 + (1 | plate) + (1 | sample))
+    ],
+    :sleepstudy => [
+        @formula(reaction ~ 1 + days + (1 | subj)),
+        @formula(reaction ~ 1 + days + zerocorr(1 + days | subj)),
+        @formula(reaction ~ 1 + days + (1 | subj) + (0 + days | subj)),
+        @formula(reaction ~ 1 + days + (1 + days | subj)),
+    ],
+)
+
+function fitbobyqa(dsnm::Symbol, i::Integer)
+    return fit(MixedModel, fms[dsnm][i], dataset(dsnm); contrasts, progress=false)
 end
 
 SUITE["simplescalar"] = BenchmarkGroup(["single", "simple", "scalar"])
-for (ds, i) in [  
-    (:dyestuff, 1,),
-    (:dyestuff2, 1,),
+for (ds, i) in [
+    (:dyestuff, 1),
+    (:dyestuff2, 1),
     (:pastes, 1),
-    (:sleepstudy, 1,),
+    (:sleepstudy, 1),
 ]
-    SUITE["simplescalar"][string(ds, ':', i)] = @benchmarkable fitbobyqa($(QuoteNode(ds)), $(QuoteNode(i)))
+    SUITE["simplescalar"][string(ds, ':', i)] = @benchmarkable fitbobyqa($ds, $i)
 end
 
 SUITE["singlevector"] = BenchmarkGroup(["single", "vector"])
-for (ds, i) in [  
-    (:sleepstudy, 2,),
-    (:sleepstudy, 3,),
-    (:sleepstudy, 4,),
+for (ds, i) in [
+    (:sleepstudy, 2),
+    (:sleepstudy, 3),
+    (:sleepstudy, 4),
 ]
-    SUITE["singlevector"][string(ds, ':', i)] = @benchmarkable fitbobyqa($(QuoteNode(ds)), $(QuoteNode(i)))
+    SUITE["singlevector"][string(ds, ':', i)] = @benchmarkable fitbobyqa($ds, $i)
 end
 
 SUITE["nested"] = BenchmarkGroup(["multiple", "nested", "scalar"])
-for (ds, i) in [  
-    (:pastes, 2,),
+for (ds, i) in [
+(:pastes, 2)
 ]
-    SUITE["nested"][string(ds, ':', i)] = @benchmarkable fitbobyqa($(QuoteNode(ds)), $(QuoteNode(i)))
+    SUITE["nested"][string(ds, ':', i)] = @benchmarkable fitbobyqa($ds, $i)
 end
 
 SUITE["crossed"] = BenchmarkGroup(["multiple", "crossed", "scalar"])
@@ -97,7 +121,7 @@ for (ds, i) in [
     (:mrk17_exp1, 1),
     (:penicillin, 1),
 ]
-    SUITE["crossed"][string(ds, ':', i)] = @benchmarkable fitbobyqa($(QuoteNode(ds)), $(QuoteNode(i)))
+    SUITE["crossed"][string(ds, ':', i)] = @benchmarkable fitbobyqa($ds, $i)
 end
 
 SUITE["crossedvector"] = BenchmarkGroup(["multiple", "crossed", "vector"])
@@ -107,5 +131,5 @@ for (ds, i) in [
     (:kb07, 3),
     (:mrk17_exp1, 2),
 ]
-    SUITE["crossedvector"][string(ds, ':', i)] = @benchmarkable fitbobyqa($(QuoteNode(ds)), $(QuoteNode(i)))
+    SUITE["crossedvector"][string(ds, ':', i)] = @benchmarkable fitbobyqa($ds, $i)
 end


### PR DESCRIPTION
- Revise benchmark code for modern Julia
- Change the global `contrasts` to a single `Dict{Symbol,Any}` instead of a `Dict` of `Dict`s.

Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [ ] I've bumped the version appropriately

No need to release these changes right away.