### PR TITLE
avoid repeated def of models method

### DIFF
--- a/test/modelcache.jl
+++ b/test/modelcache.jl
@@ -44,8 +44,11 @@ using MixedModels: dataset
 
 @isdefined(allfms) || const global allfms = merge(fms, gfms)
 
-function models(nm::Symbol)
-    get!(fittedmodels, nm) do
-        [fit(MixedModel, f, dataset(nm); progress=false) for f in allfms[nm]]
+
+if !@isdefined(models)
+    function models(nm::Symbol)
+        get!(fittedmodels, nm) do
+            [fit(MixedModel, f, dataset(nm); progress=false) for f in allfms[nm]]
+        end
     end
 end


### PR DESCRIPTION
Avoid redefinition of a method in an included file (#691)
Julia v1.10.0-DEV warns about this when running tests.