### PR TITLE
More informative error messages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+MixedModels v4.16.0 Release Notes
+==============================
+* More informative error messages when passing a `Distribution` or `Link` type instead of the desired instance.
+* More informative error message on the intentional decision not to define methods for the coefficient of determination.
+
 MixedModels v4.15.0 Release Notes
 ==============================
 * Support for different optimization criteria during the bootstrap. [#694]

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 MixedModels v4.16.0 Release Notes
 ==============================
-* More informative error messages when passing a `Distribution` or `Link` type instead of the desired instance.
-* More informative error message on the intentional decision not to define methods for the coefficient of determination.
+* More informative error messages when passing a `Distribution` or `Link` type instead of the desired instance. [#698]
+* More informative error message on the intentional decision not to define methods for the coefficient of determination. [#698]
 
 MixedModels v4.15.0 Release Notes
 ==============================
@@ -447,3 +447,4 @@ Package dependencies
 [#681]: https://github.com/JuliaStats/MixedModels.jl/issues/681
 [#682]: https://github.com/JuliaStats/MixedModels.jl/issues/682
 [#694]: https://github.com/JuliaStats/MixedModels.jl/issues/694
+[#698]: https://github.com/JuliaStats/MixedModels.jl/issues/698

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.15.0"
+version = "4.16.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -341,11 +341,10 @@ function GeneralizedLinearMixedModel(
     tbl,
     d::Distribution,
     l::Type;
-    kwargs...,
+    kwargs...
 )
     throw(ArgumentError("Expected a Link instance (`$l()`), got a type (`$l`)."))
 end
-
 
 function GeneralizedLinearMixedModel(
     f::FormulaTerm,

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -329,6 +329,27 @@ StatsAPI.fitted(m::GeneralizedLinearMixedModel) = m.resp.mu
 function GeneralizedLinearMixedModel(
     f::FormulaTerm,
     tbl,
+    d::Type,
+    args...;
+    kwargs...,
+)
+    throw(ArgumentError("Expected a Distribution instance (`$d()`), got a type (`$d`)."))
+end
+
+function GeneralizedLinearMixedModel(
+    f::FormulaTerm,
+    tbl,
+    d::Distribution,
+    l::Type;
+    kwargs...,
+)
+    throw(ArgumentError("Expected a Link instance (`$l()`), got a type (`$l`)."))
+end
+
+
+function GeneralizedLinearMixedModel(
+    f::FormulaTerm,
+    tbl,
     d::Distribution,
     l::Link=canonicallink(d);
     wts=[],

--- a/src/mixedmodel.jl
+++ b/src/mixedmodel.jl
@@ -119,6 +119,22 @@ function retbl(mat, trm)
 )
 end
 
+StatsAPI.adjr2(m::MixedModel) = r2(m)
+
+function StatsAPI.r2(m::MixedModel)
+    @error ("""There is no uniquely defined coefficient of determination for mixed models
+             that has all the properties of the corresponding value for classical 
+             linear models. The GLMM FAQ provides more detail:
+             
+             https://bbolker.github.io/mixedmodels-misc/glmmFAQ.html#how-do-i-compute-a-coefficient-of-determination-r2-or-an-analogue-for-glmms
+
+
+             Alternatively, MixedModelsExtras provides a naive implementation, but 
+             the warnings there and in the FAQ should be taken seriously!
+             """)
+    throw(MethodError(r2, (m,)))
+end
+
 """
     raneftables(m::MixedModel; uscale = false)
 

--- a/src/mixedmodel.jl
+++ b/src/mixedmodel.jl
@@ -80,7 +80,7 @@ function StatsAPI.fit(
     tbl,
     d::Type,
     args...;
-    kwargs...,
+    kwargs...
 )
     throw(ArgumentError("Expected a Distribution instance (`$d()`), got a type (`$d`)."))
 end
@@ -91,7 +91,7 @@ function StatsAPI.fit(
     tbl,
     d::Distribution,
     l::Type;
-    kwargs...,
+    kwargs...
 )
     throw(ArgumentError("Expected a Link instance (`$l()`), got a type (`$l`)."))
 end
@@ -122,16 +122,18 @@ end
 StatsAPI.adjr2(m::MixedModel) = r2(m)
 
 function StatsAPI.r2(m::MixedModel)
-    @error ("""There is no uniquely defined coefficient of determination for mixed models
-             that has all the properties of the corresponding value for classical 
-             linear models. The GLMM FAQ provides more detail:
-             
-             https://bbolker.github.io/mixedmodels-misc/glmmFAQ.html#how-do-i-compute-a-coefficient-of-determination-r2-or-an-analogue-for-glmms
+    @error (
+        """There is no uniquely defined coefficient of determination for mixed models
+         that has all the properties of the corresponding value for classical 
+         linear models. The GLMM FAQ provides more detail:
+         
+         https://bbolker.github.io/mixedmodels-misc/glmmFAQ.html#how-do-i-compute-a-coefficient-of-determination-r2-or-an-analogue-for-glmms
 
 
-             Alternatively, MixedModelsExtras provides a naive implementation, but 
-             the warnings there and in the FAQ should be taken seriously!
-             """)
+         Alternatively, MixedModelsExtras provides a naive implementation, but 
+         the warnings there and in the FAQ should be taken seriously!
+         """
+    )
     throw(MethodError(r2, (m,)))
 end
 

--- a/src/mixedmodel.jl
+++ b/src/mixedmodel.jl
@@ -74,6 +74,28 @@ issingular(m::GeneralizedLinearMixedModel, θ=m.optsum.final) = any(lowerbd(m) .
 # FIXME: better to base this on m.optsum.returnvalue
 StatsAPI.isfitted(m::MixedModel) = m.optsum.feval > 0
 
+function StatsAPI.fit(
+    ::Type{<:MixedModel},
+    f::FormulaTerm,
+    tbl,
+    d::Type,
+    args...;
+    kwargs...,
+)
+    throw(ArgumentError("Expected a Distribution instance (`$d()`), got a type (`$d`)."))
+end
+
+function StatsAPI.fit(
+    ::Type{<:MixedModel},
+    f::FormulaTerm,
+    tbl,
+    d::Distribution,
+    l::Type;
+    kwargs...,
+)
+    throw(ArgumentError("Expected a Link instance (`$l()`), got a type (`$l`)."))
+end
+
 StatsAPI.meanresponse(m::MixedModel) = mean(m.y)
 
 """

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -18,6 +18,20 @@ include("modelcache.jl")
     @test MixedModel(f, d, Bernoulli(), ProbitLink()) isa GeneralizedLinearMixedModel
 end
 
+@testset "Type for instance" begin
+    vaform = @formula(r2 ~ 1 + anger + gender + btype + situ + (1|subj) + (1|item))
+    verbagg = dataset(:verbagg)
+    @test_throws ArgumentError fit(MixedModel, vaform, verbagg, Bernoulli, LogitLink)
+    @test_throws ArgumentError fit(MixedModel, vaform, verbagg, Bernoulli(), LogitLink)
+    @test_throws ArgumentError fit(MixedModel, vaform, verbagg, Bernoulli, LogitLink())
+    @test_throws ArgumentError fit(GeneralizedLinearMixedModel, vaform, verbagg, Bernoulli, LogitLink)
+    @test_throws ArgumentError fit(GeneralizedLinearMixedModel, vaform, verbagg, Bernoulli(), LogitLink)
+    @test_throws ArgumentError fit(GeneralizedLinearMixedModel, vaform, verbagg, Bernoulli, LogitLink())
+    @test_throws ArgumentError GeneralizedLinearMixedModel(vaform, verbagg, Bernoulli, LogitLink)
+    @test_throws ArgumentError GeneralizedLinearMixedModel(vaform, verbagg, Bernoulli(), LogitLink)
+    @test_throws ArgumentError GeneralizedLinearMixedModel(vaform, verbagg, Bernoulli, LogitLink())
+end
+
 @testset "contra" begin
     contra = dataset(:contra)
     thin = 5

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -1,3 +1,4 @@
+using GLM # bring r2 into scope
 using LinearAlgebra
 using MixedModels
 using PooledArrays
@@ -5,7 +6,6 @@ using Random
 using SparseArrays
 using Suppressor
 using Statistics
-using StatsBase
 using StatsModels
 using Tables
 using Test
@@ -671,7 +671,7 @@ end
 
 @testset "methods we don't define" begin
     m = first(models(:sleepstudy))
-    for f in [StatsBase.r2, StatsBase.adjr2]
+    for f in [r2, adjr2]
         @test_logs (:error,) begin
             try
                 f(m)

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -5,6 +5,7 @@ using Random
 using SparseArrays
 using Suppressor
 using Statistics
+using StatsBase
 using StatsModels
 using Tables
 using Test
@@ -666,4 +667,18 @@ end
     # it would be great to test the handling of PosDefException after the first iteration
     # but this is surprisingly hard to trigger in a reliable way across platforms
     # just because of the vagaries of floating point.
+end
+
+@testset "methods we don't define" begin
+    m = first(models(:sleepstudy))
+    for f in [StatsBase.r2, StatsBase.adjr2]
+        @test_logs (:error,) begin
+            try
+                f(m)
+            catch
+                # capture the error, do nothing
+            end
+        end
+        @test_throws MethodError @suppress f(m)
+    end
 end


### PR DESCRIPTION
* More informative error messages when passing a `Distribution` or `Link` type instead of the desired instance.
* More informative error message on the intentional decision not to define methods for the coefficient of determination.
* NB: we still don't export `r2` or `adjr2` but these functions might be scope from some other package. We just define methods for them.

Not sure how I feel about adding in these safety features -- @dmbates please feel free to reject all or part of this.

inspired by #696 and #697



- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.
- [x] I've bumped the version appropriately
