### PR TITLE
nest log and throws tests (1.11-nightly compat)

### DIFF
--- a/src/remat.jl
+++ b/src/remat.jl
@@ -764,6 +764,6 @@ vsize(::ReMat{T,S}) where {T,S} = S
 function zerocorr!(A::ReMat{T}) where {T}
     λ = A.λ = Diagonal(A.λ)
     k = size(λ, 1)
-    A.inds = intersect(A.inds, range(1, step=k + 1, length=k))
+    A.inds = intersect(A.inds, range(1; step=k + 1, length=k))
     return A
 end

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -183,7 +183,8 @@ These are the elements in the lower triangle of `A.λ` in column-major ordering.
 Diagonals have a lower bound of `0`.  Off-diagonals have a lower-bound of `-Inf`.
 """
 function lowerbd(A::ReMat{T}) where {T}
-    return T[x ∈ diagind(A.λ) ? zero(T) : T(-Inf) for x in A.inds]
+    k = size(A.λ, 1)  # construct diagind(A.λ) by hand following #52115
+    return T[x ∈ range(1, step=k + 1, length=k) ? zero(T) : T(-Inf) for x in A.inds]
 end
 
 """
@@ -762,6 +763,7 @@ vsize(::ReMat{T,S}) where {T,S} = S
 
 function zerocorr!(A::ReMat{T}) where {T}
     λ = A.λ = Diagonal(A.λ)
-    A.inds = intersect(A.inds, diagind(λ))
+    k = size(λ, 1)
+    A.inds = intersect(A.inds, range(1, step=k + 1, length=k))
     return A
 end

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -184,7 +184,7 @@ Diagonals have a lower bound of `0`.  Off-diagonals have a lower-bound of `-Inf`
 """
 function lowerbd(A::ReMat{T}) where {T}
     k = size(A.λ, 1)  # construct diagind(A.λ) by hand following #52115
-    return T[x ∈ range(1, step=k + 1, length=k) ? zero(T) : T(-Inf) for x in A.inds]
+    return T[x ∈ range(1; step=k + 1, length=k) ? zero(T) : T(-Inf) for x in A.inds]
 end
 
 """

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -700,13 +700,6 @@ end
 @testset "methods we don't define" begin
     m = first(models(:sleepstudy))
     for f in [r2, adjr2]
-        @test_logs (:error,) begin
-            try
-                f(m)
-            catch
-                # capture the error, do nothing
-            end
-        end
-        @test_throws MethodError @suppress f(m)
+        @test_logs (:error,) @test_throws MethodError f(m)
     end
 end


### PR DESCRIPTION
I don't know what's changed in the nightly but something about catching the exception messes up the `@test_logs` check even though the error is still being logged. This fixes that and simplifies things a bit.