### PR TITLE
A test using a deep copy of a model should reset the initial parameter values.

### DIFF
--- a/test/matrixterm.jl
+++ b/test/matrixterm.jl
@@ -42,7 +42,11 @@ end
         @test typeof(X.x) <: SparseMatrixCSC
         @test X.rank == 28
         @test X.cnames == fe.cnames
-        m1 = fit!(LinearMixedModel(collect(m.y), X, deepcopy(m.reterms), m.formula); progress=false)
+        m1 = LinearMixedModel(collect(m.y), X, deepcopy(m.reterms), m.formula)
+        # because of the way the initial values are calculated
+        # m1.optsum.initial == m.optsum.final at this point
+        copyto!(m1.optsum.initial, m.optsum.initial)
+        m1 = fit!(m1; progress=false)
         @test isapprox(m1.θ, m.θ, rtol = 1.0e-5)
     end
 

--- a/test/matrixterm.jl
+++ b/test/matrixterm.jl
@@ -46,7 +46,7 @@ end
         # because of the way the initial values are calculated
         # m1.optsum.initial == m.optsum.final at this point
         copyto!(m1.optsum.initial, m.optsum.initial)
-        m1 = fit!(m1; progress=false)
+        fit!(m1; progress=false)
         @test isapprox(m1.θ, m.θ, rtol = 1.0e-5)
     end
 


### PR DESCRIPTION
Because the initial values for the theta parameters are derived from the values stored in the reterms they will be the final parameter estimates if those terms are deep copied to create a new model.

The NLopt optimizers don't object to this but the PRIMA optimizers do.