### PR TITLE
Update nightly CI to use ubuntu 22.04

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         julia-version: [nightly]
         julia-arch: [x64]
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
This is an attempt to fix the consistent CI failure of nightly, despite being able to run nightly builds without difficulty.
