### PR TITLE
add Apple silicon to CI

### DIFF
--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -22,7 +22,9 @@ jobs:
       matrix:
         julia-version: [1]
         julia-arch: [x64]
-        os: [ubuntu-22.04]
+        os: 
+         - ubuntu-22.04
+         - macOS-14 # apple silicon!
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/current.yml
+++ b/.github/workflows/current.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         julia-version: [1]
-        julia-arch: [x64]
-        os: 
+        # julia-arch: [x64]
+        os:
          - ubuntu-22.04
          - macOS-14 # apple silicon!
     steps:


### PR DESCRIPTION
no release necessary

I like the idea of testing another CPU architecture to work as further sanity check on our numerical tolerances.
