### PR TITLE
delegate as many GLMM properties as possible to internal LMM

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.24.0 Release Notes
+==============================
+* Properties for `GeneralizedLinearMixedModel` now default to delegation to the internal weighted `LinearMixedModel` when that property is not explicitly handled by `GeneralizedLinearMixedModel`. Previously, properties were delegated on an explicit basis, which meant that they had to be added manually as use cases were discovered. The downside to the new approach is that it is now possible to access properties whose definition in the LMM case doesn't match the GLMM definition when the GLMM definition hasn't been explicitly been implemented. [#767]
+
 MixedModels v4.23.1 Release Notes
 ==============================
 * Fix for `simulate!` when only the estimable coefficients for a rank-deficient model are provided. [#756]
@@ -516,3 +520,4 @@ Package dependencies
 [#748]: https://github.com/JuliaStats/MixedModels.jl/issues/748
 [#755]: https://github.com/JuliaStats/MixedModels.jl/issues/755
 [#756]: https://github.com/JuliaStats/MixedModels.jl/issues/756
+[#767]: https://github.com/JuliaStats/MixedModels.jl/issues/767

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.23.1"
+version = "4.24.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -489,12 +489,12 @@ function Base.getproperty(m::GeneralizedLinearMixedModel, s::Symbol)
         σs(m)
     elseif s == :σρs
         σρs(m)
-    elseif s ∈ (:A, :L, :optsum, :reterms, :Xymat, :feterm, :formula, :parmap)
-        getfield(m.LMM, s)
-    elseif s ∈ (:dims, :λ, :lowerbd, :corr, :PCA, :rePCA, :X)
-        getproperty(m.LMM, s)
     elseif s == :y
         m.resp.y
+    elseif !hasfield(GeneralizedLinearMixedModel, s) && s ∈ propertynames(m.LMM, true)
+        # automatically delegate as much as possible to the internal local linear approximation
+        # NB: the !hasfield call has to be first since we're calling getproperty() with m.LMM...
+        getproperty(m.LMM, s)
     else
         getfield(m, s)
     end


### PR DESCRIPTION
@dmbates is there a giant footgun I'm missing by swapping to "delegate by default" instead of "delegate by explicit list"? 

Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately
