### PR TITLE
import and re-export `lrtest`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>", "Jose Bayoan Santiago Calderon <jbs3hp@virginia.edu>"]
-version = "4.24.0"
+version = "4.24.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -38,7 +38,7 @@ using StatsModels: StatsModels, AbstractContrasts, AbstractTerm, CategoricalTerm
 using StatsModels: ConstantTerm, DummyCoding, EffectsCoding, FormulaTerm, FunctionTerm
 using StatsModels: HelmertCoding, HypothesisCoding, InteractionTerm, InterceptTerm
 using StatsModels: MatrixTerm, SeqDiffCoding, TableRegressionModel, Term
-using StatsModels: apply_schema, drop_term, formula, modelcols, term, @formula
+using StatsModels: apply_schema, drop_term, formula, lrtest, modelcols, term, @formula
 using StructTypes: StructTypes
 using Tables: Tables, columntable
 using TypedTables: TypedTables, DictTable, FlexTable, Table
@@ -114,6 +114,7 @@ export @formula,
     logdet,
     loglikelihood,
     lowerbd,
+    lrtest,
     meanresponse,
     modelmatrix,
     model_response,


### PR DESCRIPTION
- [x] I've bumped the version appropriately

treating this as a patch release -- previously it wasn't explicitly exported, but it was accessible until we moved to using explicit imports of every binding 