### PR TITLE
Force return type on pwrss and logdet to provide stable type inference on objective

### DIFF
--- a/src/linalg/logdet.jl
+++ b/src/linalg/logdet.jl
@@ -25,11 +25,11 @@ lower Cholesky factor.
 """
 function LinearAlgebra.logdet(m::LinearMixedModel{T}) where {T}
     L = m.L
-    @inbounds s = sum(j -> LD(L[kp1choose2(j)]), axes(m.reterms, 1))
+    @inbounds s = sum(j -> LD(L[kp1choose2(j)]), axes(m.reterms, 1))::T
     if m.optsum.REML
         lastL = last(L)
         s += LD(lastL)        # this includes the log of sqrtpwrss
         s -= log(last(lastL)) # so we need to subtract it from the sum
     end
-    return s + s  # multiply by 2 b/c the desired det is of the symmetric mat, not the factor
+    return (s + s)::T  # multiply by 2 b/c the desired det is of the symmetric mat, not the factor
 end

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -50,7 +50,7 @@ function LinearMixedModel(
 end
 
 const _MISSING_RE_ERROR = ArgumentError(
-    "Formula contains no random effects; this isn't a mixed model. Perhaps you want to use GLM.jl?",
+    "Formula contains no random effects; this isn't a mixed model. Perhaps you want to use GLM.jl?"
 )
 
 function LinearMixedModel(
@@ -62,7 +62,7 @@ function LinearMixedModel(
     fvars ⊆ tvars ||
         throw(
             ArgumentError(
-                "The following formula variables are not present in the table: $(setdiff(fvars, tvars))",
+                "The following formula variables are not present in the table: $(setdiff(fvars, tvars))"
             ),
         )
 
@@ -226,7 +226,7 @@ end
 function _offseterr()
     return throw(
         ArgumentError(
-            "Offsets are not supported in linear models. You can simply shift the response by the offset.",
+            "Offsets are not supported in linear models. You can simply shift the response by the offset."
         ),
     )
 end
@@ -372,7 +372,7 @@ function StatsBase.confint(m::MixedModel{T}; level=0.95) where {T}
     return DictTable(;
         coef=coefnames(m),
         lower=β .- cutoff .* std,
-        upper=β .+ cutoff .* std
+        upper=β .+ cutoff .* std,
     )
 end
 
@@ -895,7 +895,7 @@ end
 
 The penalized, weighted residual sum-of-squares.
 """
-pwrss(m::LinearMixedModel) = abs2(last(last(m.L)))
+pwrss(m::LinearMixedModel{T}) where {T} = abs2(last(last(m.L)))::T
 
 """
     ranef!(v::Vector{Matrix{T}}, m::MixedModel{T}, β, uscale::Bool) where {T}


### PR DESCRIPTION
Closes #770 

Did behavior change? Did you add need features? If so, please update NEWS.md
- [ ] add entry in NEWS.md
- [ ] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [ ] I've bumped the version appropriately
