### PR TITLE
use ::Matrix{T} instead of ::T to aid type inference

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.24.1 Release Notes
+==============================
+Add type notations in `pwrss(::LinearMixedModel)` and `logdet(::LinearMixedModel)` to enhance type inference. [#773]
+
 MixedModels v4.24.0 Release Notes
 ==============================
 * Properties for `GeneralizedLinearMixedModel` now default to delegation to the internal weighted `LinearMixedModel` when that property is not explicitly handled by `GeneralizedLinearMixedModel`. Previously, properties were delegated on an explicit basis, which meant that they had to be added manually as use cases were discovered. The downside to the new approach is that it is now possible to access properties whose definition in the LMM case doesn't match the GLMM definition when the GLMM definition hasn't been explicitly been implemented. [#767]
@@ -521,3 +525,4 @@ Package dependencies
 [#755]: https://github.com/JuliaStats/MixedModels.jl/issues/755
 [#756]: https://github.com/JuliaStats/MixedModels.jl/issues/756
 [#767]: https://github.com/JuliaStats/MixedModels.jl/issues/767
+[#773]: https://github.com/JuliaStats/MixedModels.jl/issues/773

--- a/src/generalizedlinearmixedmodel.jl
+++ b/src/generalizedlinearmixedmodel.jl
@@ -351,7 +351,7 @@ function GeneralizedLinearMixedModel(
     tbl,
     d::Distribution,
     l::Type;
-    kwargs...
+    kwargs...,
 )
     throw(ArgumentError("Expected a Link instance (`$l()`), got a type (`$l`)."))
 end
@@ -376,7 +376,7 @@ function GeneralizedLinearMixedModel(
     tbl::Tables.ColumnTable,
     d::Normal,
     l::IdentityLink;
-    kwargs...
+    kwargs...,
 )
     return throw(
         ArgumentError("use LinearMixedModel for Normal distribution with IdentityLink")

--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -219,7 +219,7 @@ function _iscomparable(m::LinearMixedModel...)
     if any(getproperty.(getproperty.(m, :optsum), :REML))
         isconstant(coefnames.(m)) || throw(
             ArgumentError(
-                "Likelihood-ratio tests for REML-fitted models are only valid when the fixed-effects specifications are identical",
+                "Likelihood-ratio tests for REML-fitted models are only valid when the fixed-effects specifications are identical"
             ),
         )
     end

--- a/src/linalg/logdet.jl
+++ b/src/linalg/logdet.jl
@@ -25,9 +25,9 @@ lower Cholesky factor.
 """
 function LinearAlgebra.logdet(m::LinearMixedModel{T}) where {T}
     L = m.L
-    @inbounds s = sum(j -> LD(L[kp1choose2(j)]), axes(m.reterms, 1))::T
+    @inbounds s = sum(j -> LD(L[kp1choose2(j)])::T, axes(m.reterms, 1))
     if m.optsum.REML
-        lastL = last(L)
+        lastL = last(L)::Matrix{T}
         s += LD(lastL)        # this includes the log of sqrtpwrss
         s -= log(last(lastL)) # so we need to subtract it from the sum
     end

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -12,7 +12,7 @@ function rankUpdate! end
 
 function rankUpdate!(C::AbstractMatrix, a::AbstractArray, α, β)
     return error(
-        "We haven't implemented a method for $(typeof(C)), $(typeof(a)). Please file an issue on GitHub.",
+        "We haven't implemented a method for $(typeof(C)), $(typeof(a)). Please file an issue on GitHub."
     )
 end
 

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -895,7 +895,7 @@ end
 
 The penalized, weighted residual sum-of-squares.
 """
-pwrss(m::LinearMixedModel{T}) where {T} = abs2(last(last(m.L)))::T
+pwrss(m::LinearMixedModel{T}) where {T} = abs2(last(last(m.L)::Matrix{T}))
 
 """
     ranef!(v::Vector{Matrix{T}}, m::MixedModel{T}, β, uscale::Bool) where {T}

--- a/src/mixedmodel.jl
+++ b/src/mixedmodel.jl
@@ -80,7 +80,7 @@ function StatsAPI.fit(
     tbl,
     d::Type,
     args...;
-    kwargs...
+    kwargs...,
 )
     throw(ArgumentError("Expected a Distribution instance (`$d()`), got a type (`$d`)."))
 end
@@ -91,7 +91,7 @@ function StatsAPI.fit(
     tbl,
     d::Distribution,
     l::Type;
-    kwargs...
+    kwargs...,
 )
     throw(ArgumentError("Expected a Link instance (`$l()`), got a type (`$l`)."))
 end

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -115,7 +115,7 @@ function _predict(m::MixedModel{T}, newdata, β; new_re_levels) where {T}
             any(any(ismissing, Tables.getcolumn(newdata, col)) for col in respvars)
             throw(
                 ArgumentError(
-                    "Response column must be initialized to a non-missing numeric value.",
+                    "Response column must be initialized to a non-missing numeric value."
                 ),
             )
         end

--- a/src/profile/thetapr.jl
+++ b/src/profile/thetapr.jl
@@ -10,7 +10,7 @@ function optsumj(os::OptSummary, j::Integer)
     return OptSummary(
         deleteat!(copy(os.final), j),
         deleteat!(copy(os.lowerbd), j),
-        os.optimizer
+        os.optimizer,
     )
 end
 

--- a/src/randomeffectsterm.jl
+++ b/src/randomeffectsterm.jl
@@ -174,7 +174,7 @@ function StatsModels.apply_schema(
     if !(typeof(first) <: CategoricalTerm)
         throw(
             ArgumentError(
-                "nesting terms requires categorical grouping term, got $first.  Manually specify $first as `CategoricalTerm` in hints/contrasts",
+                "nesting terms requires categorical grouping term, got $first.  Manually specify $first as `CategoricalTerm` in hints/contrasts"
             ),
         )
     end

--- a/src/remat.jl
+++ b/src/remat.jl
@@ -586,7 +586,7 @@ end
 function copyscaleinflate!(
     Ljj::UniformBlockDiagonal{T},
     Ajj::UniformBlockDiagonal{T},
-    Λj::ReMat{T,S}
+    Λj::ReMat{T,S},
 ) where {T,S}
     λ = Λj.λ
     dind = diagind(S, S)
@@ -604,7 +604,7 @@ end
 function copyscaleinflate!(
     Ljj::Matrix{T},
     Ajj::UniformBlockDiagonal{T},
-    Λj::ReMat{T,S}
+    Λj::ReMat{T,S},
 ) where {T,S}
     copyto!(Ljj, Ajj)
     n = LinearAlgebra.checksquare(Ljj)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -236,7 +236,7 @@ function _simulate!(
         ismissing(σ) ||
         throw(
             ArgumentError(
-                "You must not specify a dispersion parameter for model families without a dispersion parameter",
+                "You must not specify a dispersion parameter for model families without a dispersion parameter"
             ),
         )
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -136,7 +136,7 @@ function replicate(
 )
     use_threads && Base.depwarn(
         "use_threads is deprecated and will be removed in a future release",
-        :replicate
+        :replicate,
     )
     if !isnothing(hide_progress)
         Base.depwarn(


### PR DESCRIPTION
I think this is a slightly more effective (even more microseconds saved!) way of enhancing the type inference.

Did behavior change? Did you add need features? If so, please update NEWS.md
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately
