### PR TITLE
bump minimum tested compat for macOS to Monterey

### DIFF
--- a/.github/workflows/minimum.yml
+++ b/.github/workflows/minimum.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         julia-version: [1.8]
         julia-arch: [x64]
-        os: [ubuntu-22.04, macos-11, windows-2019]
+        os: [ubuntu-22.04, macos-12, windows-2019]
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Typical distribution forms are _Bernoulli_ for binary data or _Poisson_ for coun
 |Linux   | Ubuntu 20.04  | x64 |v1.8            |
 |Linux   | Ubuntu 20.04  | x64 |current release |
 |Linux   | Ubuntu 20.04  | x64 |nightly         |
-|macOS   | Catalina 10.15| x64 |v1.8            |
+|macOS   | Monterey 12   | x64 |v1.8            |
 |Windows | Server 2019   | x64 |v1.8            |
 
 Note that previous releases still support older Julia versions.


### PR DESCRIPTION
It's increasingly hard to impossible to get the older macOS 11 Big Sur runners and that OS is no longer supported by Apple.