### PR TITLE
Allow simulating from GLMM distributions that we can't fit 

### DIFF
--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -7,7 +7,7 @@ using BSplineKit: interpolate
 using Compat: @compat
 using DataAPI: DataAPI, levels, refpool, refarray, refvalue
 using Distributions: Distributions, Bernoulli, Binomial, Chisq, Distribution, Gamma
-using Distributions: InverseGaussian, Normal, Poisson, ccdf
+using Distributions: Geometric, InverseGaussian, Normal, Poisson, ccdf
 using GLM: GLM, GeneralizedLinearModel, IdentityLink, InverseLink, LinearModel
 using GLM: Link, LogLink, LogitLink, ProbitLink, SqrtLink
 using GLM: canonicallink, glm, linkinv, dispersion, dispersion_parameter
@@ -55,6 +55,7 @@ export @formula,
     Grouping,
     Gamma,
     GeneralizedLinearMixedModel,
+    Geometric,
     HelmertCoding,
     HypothesisCoding,
     IdentityLink,

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -91,7 +91,7 @@ function _rand(rng::AbstractRNG, ::Normal, location, scale=missing, n=1)
 end
 
 function _rand(::AbstractRNG, ::T, ::Any, scale=missing, n=1) where T <: Distribution
-    throw(ArgumentError("Families with a dispersion parameter not yet supported"))
+    throw(ArgumentError("$(nameof(T)) distribution is not currently supported"))
 end
 
 function simulate!(m::MixedModel{T}; β=fixef(m), σ=m.σ, θ=T[]) where {T}

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -87,8 +87,7 @@ end
 
 function _rand(rng::AbstractRNG, ::Normal, location, scale=missing, n=1)
     # skip constructing a distribution
-    # return scale * randn(rng) + location
-    throw(ArgumentError("Families with a dispersion parameter not yet supported"))
+    return scale * randn(rng) + location
 end
 
 function _rand(::AbstractRNG, ::T, ::Any, scale=missing, n=1) where T <: Distribution

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -75,18 +75,24 @@ Note that `n` is the `n` parameter for the Binomial distribution,
 *not* the number of draws from the RNG. It is then used to change the
 random draw (an integer in [0, n]) into a probability (a float in [0,1]).
 """
-function _rand(rng::AbstractRNG, d::Distribution, location, scale=NaN, n=1)
-    if !ismissing(scale)
-        throw(ArgumentError("Families with a dispersion parameter not yet supported"))
-    end
-
-    if d isa Binomial
-        dist = Binomial(Int(n), location)
-    else
-        dist = typeof(d)(location)
-    end
-
+function _rand(rng::AbstractRNG, ::Binomial, location, scale=missing, n=1)
+    dist = Binomial(Int(n), location) 
     return rand(rng, dist) / n
+end
+
+function _rand(rng::AbstractRNG, ::T, location, scale=missing, n=1) where T <: Union{Bernoulli,Poisson}
+    dist = T(location)
+    return rand(rng, dist)
+end    
+
+function _rand(rng::AbstractRNG, ::Normal, location, scale=missing, n=1)
+    # skip constructing a distribution
+    # return scale * randn(rng) + location
+    throw(ArgumentError("Families with a dispersion parameter not yet supported"))
+end
+
+function _rand(::AbstractRNG, ::T, ::Any, scale=missing, n=1) where T <: Distribution
+    throw(ArgumentError("Families with a dispersion parameter not yet supported"))
 end
 
 function simulate!(m::MixedModel{T}; β=fixef(m), σ=m.σ, θ=T[]) where {T}

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -65,9 +65,14 @@ end
         @test isapprox(gm2.β, gm2sim.β; atol=norm(stderror(gm2)))
     end
     @testset "_rand with dispersion" begin
-        @test_throws ArgumentError MixedModels._rand(StableRNG(42), Normal(), 1, 1, 1)
-        @test_throws ArgumentError MixedModels._rand(StableRNG(42), Gamma(), 1, 1, 1)
-        @test_throws ArgumentError MixedModels._rand(StableRNG(42), InverseGaussian(), 1, 1, 1)
+        @test_throws ArgumentError MixedModels._rand(StableRNG(42), Gamma(), 1)
+        @test_throws ArgumentError MixedModels._rand(StableRNG(42), InverseGaussian(), 1)
+
+        data = (; y=fill(1, 1000), g=rand('A':'G', 1000))
+        m = @suppress MixedModel(@formula(y ~ 1 + (1|g)), data, Normal(), LogLink())
+        simulate!(m; β=[1], θ=[0], σ=1)
+        v = response(m)
+        @test mean(v) ≈ exp(1) atol=0.05
     end
 end
 

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -64,6 +64,23 @@ end
         gm2sim = refit!(simulate!(StableRNG(42), deepcopy(gm2)); fast=true, progress=false)
         @test isapprox(gm2.β, gm2sim.β; atol=norm(stderror(gm2)))
     end
+
+    @testset "Geometric" begin
+        n = 1000
+        data = (; y=fill(1, n), g=rand('A':'G', n))
+        data = (; y=rand(StableRNG(42), Geometric(0.5), n),
+                  g=rand('A':'G', n))
+        @test_logs (:warn, r"geometric") MixedModel(@formula(y ~ 1 + (1|g)), data, Geometric())
+        m = @suppress MixedModel(@formula(y ~ 1 + (1|g)), data, Geometric())
+        v = simulate(StableRNG(42), m; β=[exp(0.5)], θ=[0])
+        gmean = mean(rand(StableRNG(42), Geometric(), n))
+        @test mean(v) ≈ gmean atol=0.005
+
+        simulate!(StableRNG(42), m; β=[exp(0.5)], θ=[0])
+        v = response(m)
+        @test mean(v) ≈ gmean atol=0.005
+    end
+
     @testset "_rand with dispersion" begin
         @test_throws ArgumentError MixedModels._rand(StableRNG(42), NegativeBinomial(), 1, 1)
 


### PR DESCRIPTION
- [ ] add entry in NEWS.md
- [ ] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.
- [ ] I've bumped the version appropriately

Even if we can't estimate these parameters, we can still _use_ them.