### PR TITLE
Reset m.optsum.feval in prfit! to show model has been fit

### DIFF
--- a/ext/MixedModelsPRIMAExt.jl
+++ b/ext/MixedModelsPRIMAExt.jl
@@ -4,10 +4,7 @@ using MixedModels: MixedModels, LinearMixedModel, objective!
 using PRIMA: PRIMA
 
 function MixedModels.prfit!(m::LinearMixedModel)
-    θ, info = PRIMA.bobyqa(objective!(m), copy(m.optsum.initial); xl=m.optsum.lowerbd)
-    if θ ≠ m.θ   # force an evaluation of the objective at the optimum
-        objective!(m, θ)
-    end
+    info = PRIMA.bobyqa!(objective!(m), copy(m.optsum.initial); xl=m.optsum.lowerbd)
     m.optsum.feval = info.nf
     return m
 end

--- a/ext/MixedModelsPRIMAExt.jl
+++ b/ext/MixedModelsPRIMAExt.jl
@@ -4,7 +4,11 @@ using MixedModels: MixedModels, LinearMixedModel, objective!
 using PRIMA: PRIMA
 
 function MixedModels.prfit!(m::LinearMixedModel)
-    PRIMA.bobyqa!(objective!(m), copy(m.optsum.initial); xl=m.optsum.lowerbd)
+    θ, info = PRIMA.bobyqa(objective!(m), copy(m.optsum.initial); xl=m.optsum.lowerbd)
+    if θ ≠ m.θ   # force an evaluation of the objective at the optimum
+        objective!(m, θ)
+    end
+    m.optsum.feval = info.nf
     return m
 end
 


### PR DESCRIPTION
- The `prfit!` method did not reset `m.optsum.feval` so the model was not recognized as having been fit.
- We should discuss how far we want to go in modifying m.optsum within `prfit!`.

Did behavior change? Did you add need features? If so, please update NEWS.md
- [ ] add entry in NEWS.md
- [ ] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [ ] I've bumped the version appropriately
