### PR TITLE
added function aliases that dont contain unicode characters for convenience

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.31.0 Release Notes
+==============================
+- Added aliases `settheta!` and `profilesigma` for the functions `setθ!` and `profileσ` respectively
+
 MixedModels v4.30.0 Release Notes
 ==============================
 - Refactor calls to backend optimizer to make it easier to add and use different optimization backends.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>"]
-version = "4.30.1"
+version = "4.31.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -212,8 +212,8 @@ include("prima.jl")
 
 
 # aliases with non-unicode function names
-settheta! = setθ!
-profilesigma = profileσ
+const settheta! = setθ!
+const profilesigma = profileσ
 
 # COV_EXCL_START
 @setup_workload begin

--- a/src/MixedModels.jl
+++ b/src/MixedModels.jl
@@ -125,6 +125,7 @@ export @formula,
     predict,
     profile,
     profileσ,
+    profilesigma,
     profilevc,
     pwrss,
     ranef,
@@ -143,6 +144,7 @@ export @formula,
     shortestcovint,
     sdest,
     setθ!,
+    settheta!,
     simulate,
     simulate!,
     sparse,
@@ -207,6 +209,11 @@ include("serialization.jl")
 include("profile/profile.jl")
 include("nlopt.jl")
 include("prima.jl")
+
+
+# aliases with non-unicode function names
+settheta! = setθ!
+profilesigma = profileσ
 
 # COV_EXCL_START
 @setup_workload begin

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -16,3 +16,8 @@ using MixedModels: dataset
     @test_throws MixedModels._MISSING_RE_ERROR  MixedModel(@formula(yield ~ 0 + batch), dyestuff, Poisson())
     @test_throws MixedModels._MISSING_RE_ERROR  MixedModel(@formula(yield ~ 1), dyestuff, Poisson())
 end
+
+@testset "non-unicode function aliases for exports" begin
+    @test settheta! === setθ!
+    @test profilesigma === profileσ
+end


### PR DESCRIPTION
this (draft) PR adds `settheta!` and `profilesigma` as aliases for `setθ!` and `profileσ` respectively. This is useful when displaying code in LaTeX. One place where this is really needed is arxiv preprints, as arxiv does not (currently) accept xelatex or lualatex, and making unicode symbols work in pdflatex adds a lot of burden. 

Tagging @dmbates as he might have suggestions/comments. 