### PR TITLE
RFC: implemented StatsModels.lrtest , fixes #683

### DIFF
--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -287,6 +287,20 @@ function StatsModels.isnested(m1::MixedModel, m2::MixedModel; atol::Real=0.0)
     return true
 end
 
+function StatsModels.isnested(m::MixedModel...)::Bool
+    m  = collect(m)
+
+    for i in eachindex(m)[begin:end-1]
+        StatsModels.isnested(m[i], m[i+1]) || return false
+    end
+    return true
+end
+
+function StatsModels.lrtest(m::MixedModel...)
+    StatsModels.isnested(m...) || throw(ArgumentError("Models are not nested"))
+    likelihoodratiotest(m...)
+end
+
 function _iscomparable(
     m1::TableRegressionModel{<:Union{LinearModel,GeneralizedLinearModel}}, m2::MixedModel
 )


### PR DESCRIPTION
Issue #683 talks about adding `StatsModels.lrtest`. If I understood the code correctly, the only thing that was different from `likelihoodratiotest` was checking if models are nested. I implemented an `StatsModels.isnested` function that takes any number of `MixedModels`, and used that to implement `StatsModels.lrtest`

Did behavior change? Did you add need features? If so, please update NEWS.md
- [ ] add entry in NEWS.md
- [ ] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [ ] I've bumped the version appropriately
