### PR TITLE
added text in `constructors.md` to say NaN correlation is printed as a dot, fixes #819

### DIFF
--- a/docs/src/constructors.md
+++ b/docs/src/constructors.md
@@ -185,7 +185,7 @@ fit(MixedModel, @formula(reaction ~ 1 + days + (1|subj) + (days|subj)), sleepstu
     contrasts = Dict(:days => DummyCoding()))
 DisplayAs.Text(ans) # hide
 ```
-(Notice that the variance component for `days: 1` is estimated as zero, so the correlations for this component are undefined and expressed as `NaN`, not a number.)
+(Notice that the variance component for `days: 1` is estimated as zero, so the correlations for this component are undefined, printed as a `.` in the output and internally represented as `NaN`, not a number.)
 
 An alternative is to force all the levels of `days` as indicators using `fulldummy` encoding.
 ```@docs


### PR DESCRIPTION
fixes #819 