### PR TITLE
Allow version 0.19 of BSplineKit - to silence warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v4.34.1 Release Notes
+==============================
+- Allow v0.19.0 of `BSplineKit.jl` to avoid warnings in `beta` and `nightly` versions of julia. (#823)
+
 MixedModels v4.34.0 Release Notes
 ==============================
 - `BlockedSparse` is now immutable. [#815]
@@ -622,3 +626,4 @@ Package dependencies
 [#810]: https://github.com/JuliaStats/MixedModels.jl/issues/810
 [#814]: https://github.com/JuliaStats/MixedModels.jl/issues/814
 [#815]: https://github.com/JuliaStats/MixedModels.jl/issues/815
+[#823]: https://github.com/JuliaStats/MixedModels.jl/issues/823

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>"]
-version = "4.34.0"
+version = "4.34.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -39,7 +39,7 @@ MixedModelsPRIMAExt = ["PRIMA"]
 [compat]
 Aqua = "0.8"
 Arrow = "1, 2"
-BSplineKit = "0.14, 0.15, 0.16, 0.17, 0.18"
+BSplineKit = "0.17, 0.18, 0.19"
 Compat = "4.10"
 DataAPI = "1"
 DataFrames = "1"


### PR DESCRIPTION
Did behavior change? Did you add need features? If so, please update NEWS.md. 

The only change is to allow version 0.19 of BSplineKit which does not generate warnings in julia-v0.12-beta and julia-v0.13-nightly.
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately
