### PR TITLE
fix for Grouping() with latest CategoricalArrays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v5.0.1 Release Notes
+==============================
+- Fixes a method error with `Grouping()` contrasts when used with recent CategoricalArray releases. [#860]
+
 MixedModels v5.0.0 Release Notes
 ==============================
 - Optimization is now performed _without constraints_. In a post-fitting step, the Cholesky factor is canonicalized to have non-negative diagonal elements. [#840]
@@ -685,3 +689,4 @@ Package dependencies
 [#856]: https://github.com/JuliaStats/MixedModels.jl/issues/856
 [#857]: https://github.com/JuliaStats/MixedModels.jl/issues/857
 [#858]: https://github.com/JuliaStats/MixedModels.jl/issues/858
+[#860]: https://github.com/JuliaStats/MixedModels.jl/issues/860

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>"]
-version = "5.0.0"
+version = "5.0.1"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -46,6 +46,7 @@ MixedModelsPRIMAExt = ["PRIMA"]
 Aqua = "0.8"
 Arrow = "1, 2"
 BSplineKit = "0.17, 0.18, 0.19"
+CategoricalArrays = "0.10, 1"
 Compat = "4.10"
 DataAPI = "1"
 DataFrames = "1"
@@ -84,6 +85,7 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
@@ -96,4 +98,4 @@ Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "DataFrames", "ExplicitImports", "FiniteDiff", "ForwardDiff", "InteractiveUtils", "PRIMA", "StableRNGs", "Suppressor", "Test"]
+test = ["Aqua", "CategoricalArrays", "DataFrames", "ExplicitImports", "FiniteDiff", "ForwardDiff", "InteractiveUtils", "PRIMA", "StableRNGs", "Suppressor", "Test"]

--- a/src/grouping.jl
+++ b/src/grouping.jl
@@ -31,6 +31,7 @@ end
 function StatsModels.ContrastsMatrix(
     contrasts::Grouping, levels::AbstractVector
 )
+    levels = convert(Vector, levels)
     return StatsModels.ContrastsMatrix(zeros(0, 0), levels, levels, contrasts)
 end
 

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -14,8 +14,6 @@ end
     d = (; y=rand(2_000_000),
         grp=string.([1:1_000_000; 1:1_000_000]),
         outer=rand('A':'z', 2_000_000))
-    ## OOM seems to result in the process being killed on Mac so this messes up CI
-    # @test_throws OutOfMemoryError schema(d)
     sch = schema(d, Dict(:grp => Grouping()))
     t = sch[term(:grp)]
     @test t isa CategoricalTerm{Grouping}
@@ -27,6 +25,16 @@ end
 
     @test all(t.contrasts.invindex[lev] == i for (i, lev) in enumerate(levs))
     @test all(t.contrasts.levels[i] == lev for (i, lev) in enumerate(levs))
+
+    d = (; y=rand(20),
+         grp=categorical([1:10; 1:10]))
+    sch = schema(d, Dict(:grp => Grouping()))
+    t = sch[term(:grp)]
+    @test t isa CategoricalTerm{Grouping}
+    @test size(t.contrasts.matrix) == (0, 0)
+    @test length(t.contrasts.levels) == 10
+    @test_throws ErrorException StatsModels.modelcols(t, (a=1.0,))
+
 end
 
 @testset "Auto application of Grouping()" begin

--- a/test/grouping.jl
+++ b/test/grouping.jl
@@ -2,6 +2,7 @@ using MixedModels
 using StatsModels
 using Test
 
+using CategoricalArrays: categorical
 using MixedModels: schematize
 using StatsModels: ContrastsMatrix, FullDummyCoding
 


### PR DESCRIPTION
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.
- [x] I've bumped the version appropriately
