### PR TITLE
json serialization of mixedmodelsbootstrap

### DIFF
--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -158,3 +158,4 @@ function saveoptsum(filename, m::MixedModel)
 end
 
 # TODO, maybe: something nice for the MixedModelBootstrap
+StructTypes.excludes(::Type{<:MixedModelBootstrap}) = (:fits, :lowerbd)


### PR DESCRIPTION
the idea is to serialize everything but the replicates into a json object, that we can then pack into the arrow metadata of the table of fits 

- [ ] add entry in NEWS.md
- [ ] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.
- [ ] I've bumped the version appropriately
