### PR TITLE
isnested of a model w/o fixed effects always true

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v5.4.0 Release Notes
+==============================
+- Change `isnested(x, y)` for MixedModels to return `true` if `x` has no fixed-effects parameters [#886]
+
 MixedModels v5.3.0 Release Notes
 ==============================
 - Implement `sparseL` as a specialization of `sparsemat`. Replace `_coord` utility with `_findnz` which, in most cases, falls through to `SparseArrays.findnz`. [#880]
@@ -730,3 +734,4 @@ Package dependencies
 [#875]: https://github.com/JuliaStats/MixedModels.jl/issues/875
 [#876]: https://github.com/JuliaStats/MixedModels.jl/issues/876
 [#880]: https://github.com/JuliaStats/MixedModels.jl/issues/880
+[#886]: https://github.com/JuliaStats/MixedModels.jl/issues/886

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>"]
-version = "5.3.1"
+version = "5.4.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/likelihoodratiotest.jl
+++ b/src/likelihoodratiotest.jl
@@ -405,7 +405,9 @@ function _isnested(x::AbstractMatrix, y::AbstractMatrix; rtol=1e-8, ranktol=1e-8
     # in the same way (b/c same data) and we don't care OR
     # it's not the same data/fixef specification and we're
     # extra conservative
-    size(x, 2) <= size(y, 2) || return false
+    xcols = size(x, 2)
+    iszero(xcols) && return true
+    xcols <= size(y, 2) || return false
 
     qy = qr(y).Q
 

--- a/test/likelihoodratiotest.jl
+++ b/test/likelihoodratiotest.jl
@@ -59,6 +59,14 @@ include("modelcache.jl")
         progress=false,
     )
     @test @suppress !isnested(m1, m2)
+
+    m1 = only(models(:dyestuff))
+    m2 = fit(
+        MixedModel,
+        @formula(yield - 1500 ~ 0 + (1 | batch)),
+        dataset(:dyestuff),
+    )
+    @test isnested(m2, m1)
 end
 
 @testset "likelihoodratio test" begin


### PR DESCRIPTION
As described in #883, an error was thrown from `isnested(m2, m1)` if `m2` had no fixed-effects parameters - now returns `true`.

- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.

Should we release your changes right away? If so, bump the version:
- [x] I've bumped the version appropriately
