### PR TITLE
Remove redundant storage of the fixed effects model matrix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+MixedModels v5.5.0 Release Notes
+==============================
+- The construction of `LinearMixedModel` has changed so that the storage of the full-rank fixed-effects model matrix is shared between `feterm` and `Xymat`. The function `modelmatrix` still returns the entire model matrix (including redundant columns), but now constructs it dynamically instead of returning a reference into internal storage. The precise storage details of `FeTerm` have changed. [#889]
+
+
 MixedModels v5.4.0 Release Notes
 ==============================
 - Change `isnested(x, y)` for MixedModels to return `true` if `x` has no fixed-effects parameters [#886]
@@ -738,5 +743,6 @@ Package dependencies
 [#875]: https://github.com/JuliaStats/MixedModels.jl/issues/875
 [#876]: https://github.com/JuliaStats/MixedModels.jl/issues/876
 [#880]: https://github.com/JuliaStats/MixedModels.jl/issues/880
-[#886]: https://github.com/JuliaStats/MixedModels.jl/issues/886
 [#885]: https://github.com/JuliaStats/MixedModels.jl/issues/885
+[#886]: https://github.com/JuliaStats/MixedModels.jl/issues/886
+[#889]: https://github.com/JuliaStats/MixedModels.jl/issues/889

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>"]
-version = "5.4.0"
+version = "5.5.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/Xymat.jl
+++ b/src/Xymat.jl
@@ -8,6 +8,11 @@ Typically, an `FeTerm` represents the model matrix for the fixed effects.
 !!! note
     `FeTerm` is not the same as [`FeMat`](@ref)!
 
+!!! warning
+    In a [`LinearMixedModel`](@ref), `fullrankx` is a view into the first `rank` columns
+    of the model's `Xymat.xy` matrix. Writing to it (e.g. via `copyto!`) will propagate
+    into `Xymat.xy` and corrupt the model's internal state.
+
 # Fields
 * `fullrankx`: full-rank columns of the model matrix (a view into [`FeMat`](@ref) storage when part of a fitted [`LinearMixedModel`](@ref))
 * `xrankdef`: rank-deficient extra columns (n×(p-rank) `Matrix`; empty for full-rank models)
@@ -95,6 +100,16 @@ Return the pivot associated with the FeTerm.
 @inline pivot(m::MixedModel) = pivot(m.feterm)
 @inline pivot(A::FeTerm) = A.piv
 
+"""
+    fullrankx(m::MixedModel)
+    fullrankx(A::FeTerm)
+
+Return the full-rank portion of the fixed-effects model matrix.
+
+For a [`LinearMixedModel`](@ref) this is a non-allocating view into the first `rank`
+columns of `m.Xymat.xy`. See also [`modelmatrix`](@ref) for an allocating version that
+includes any rank-deficient columns.
+"""
 function fullrankx(A::FeTerm)
     return getfield(A, :fullrankx)
 end
@@ -119,7 +134,9 @@ A matrix and a (possibly) weighted copy of itself.
 Typically, an `FeMat` represents the fixed-effects model matrix with the response (`y`) concatenated as a final column.
 
 !!! note
-    `FeMat` is not the same as [`FeTerm`](@ref).
+    `FeMat` is not the same as [`FeTerm`](@ref). In a [`LinearMixedModel`](@ref), the
+    first `rank` columns of `xy` are aliased with the `fullrankx` field of the model's
+    [`FeTerm`](@ref); writes to either propagate to the other.
 
 # Fields
 - `xy`: original matrix, called `xy` b/c in practice this is `hcat(fullrank(X), y)`

--- a/src/Xymat.jl
+++ b/src/Xymat.jl
@@ -87,7 +87,9 @@ function FeTerm(X::SparseMatrixCSC, cnms::AbstractVector{String})
     return FeTerm{eltype(X),typeof(X)}(X, empty_rd, collect(1:rank), rank, collect(cnms))
 end
 
-Base.copyto!(A::FeTerm{T}, src::AbstractVecOrMat{T}) where {T} = copyto!(getfield(A, :fullrankx), src)
+function Base.copyto!(A::FeTerm{T}, src::AbstractVecOrMat{T}) where {T}
+    return copyto!(getfield(A, :fullrankx), src)
+end
 
 Base.eltype(::FeTerm{T}) where {T} = T
 

--- a/src/Xymat.jl
+++ b/src/Xymat.jl
@@ -9,16 +9,36 @@ Typically, an `FeTerm` represents the model matrix for the fixed effects.
     `FeTerm` is not the same as [`FeMat`](@ref)!
 
 # Fields
-* `x`: full model matrix
+* `fullrankx`: full-rank columns of the model matrix (a view into [`FeMat`](@ref) storage when part of a fitted [`LinearMixedModel`](@ref))
+* `xrankdef`: rank-deficient extra columns (n×(p-rank) `Matrix`; empty for full-rank models)
 * `piv`: pivot `Vector{Int}` for moving linearly dependent columns to the right
 * `rank`: computational rank of `x`
 * `cnames`: vector of column names
+
+# Properties
+* `x`: full model matrix (all columns, pivoted order); a non-allocating view for full-rank models,
+  or a freshly allocated `hcat` for rank-deficient models. See also [`modelmatrix`](@ref).
 """
 struct FeTerm{T,S<:AbstractMatrix}
-    x::S
+    fullrankx::S
+    xrankdef::Matrix{T}
     piv::Vector{Int}
     rank::Int
     cnames::Vector{String}
+end
+
+function Base.getproperty(A::FeTerm, sym::Symbol)
+    if sym === :x
+        fr = getfield(A, :fullrankx)
+        rd = getfield(A, :xrankdef)
+        return isempty(rd) ? fr : hcat(fr, rd)
+    end
+    return getfield(A, sym)
+end
+
+function Base.propertynames(::FeTerm, private::Bool=false)
+    public = (:x, :piv, :rank, :cnames)
+    return private ? (public..., :fullrankx, :xrankdef) : public
 end
 
 """
@@ -30,8 +50,9 @@ See the vignette "[Rank deficiency in mixed-effects models](@ref)" for more info
 computation of the rank and pivot.
 """
 function FeTerm(X::AbstractMatrix{T}, cnms) where {T}
+    n = size(X, 1)
     if iszero(size(X, 2))
-        return FeTerm{T,typeof(X)}(X, Int[], 0, cnms)
+        return FeTerm{T,typeof(X)}(X, Matrix{T}(undef, n, 0), Int[], 0, cnms)
     end
     rank, pivot = statsrank(X)
     # single-column rank deficiency is the result of a constant column vector
@@ -40,7 +61,10 @@ function FeTerm(X::AbstractMatrix{T}, cnms) where {T}
     if rank < length(pivot) && size(X, 2) > 1
         @warn "Fixed-effects matrix is rank deficient"
     end
-    return FeTerm{T,typeof(X)}(X[:, pivot], pivot, rank, cnms[pivot])
+    x_piv = X[:, pivot]
+    xfr = x_piv[:, 1:rank]
+    xrd = x_piv[:, (rank + 1):end]
+    return FeTerm{T,typeof(xfr)}(xfr, xrd, pivot, rank, cnms[pivot])
 end
 
 """
@@ -54,10 +78,11 @@ the vignette "[Rank deficiency in mixed-effects models](@ref)" for general `FeTe
 function FeTerm(X::SparseMatrixCSC, cnms::AbstractVector{String})
     #@debug "Full rank is assumed for sparse fixed-effect matrices."
     rank = size(X, 2)
-    return FeTerm{eltype(X),typeof(X)}(X, collect(1:rank), rank, collect(cnms))
+    empty_rd = Matrix{eltype(X)}(undef, size(X, 1), 0)
+    return FeTerm{eltype(X),typeof(X)}(X, empty_rd, collect(1:rank), rank, collect(cnms))
 end
 
-Base.copyto!(A::FeTerm{T}, src::AbstractVecOrMat{T}) where {T} = copyto!(A.x, src)
+Base.copyto!(A::FeTerm{T}, src::AbstractVecOrMat{T}) where {T} = copyto!(getfield(A, :fullrankx), src)
 
 Base.eltype(::FeTerm{T}) where {T} = T
 
@@ -71,8 +96,7 @@ Return the pivot associated with the FeTerm.
 @inline pivot(A::FeTerm) = A.piv
 
 function fullrankx(A::FeTerm)
-    x, rnk = A.x, A.rank
-    return rnk == size(x, 2) ? x : view(x, :, 1:rnk)  # this handles the zero-columns case
+    return getfield(A, :fullrankx)
 end
 
 fullrankx(m::MixedModel) = fullrankx(m.feterm)

--- a/src/Xymat.jl
+++ b/src/Xymat.jl
@@ -61,7 +61,7 @@ function FeTerm(X::AbstractMatrix{T}, cnms) where {T}
     if rank < length(pivot) && size(X, 2) > 1
         @warn "Fixed-effects matrix is rank deficient"
     end
-    x_piv = X[:, pivot]
+    x_piv = view(X, :, pivot)
     xfr = x_piv[:, 1:rank]
     xrd = x_piv[:, (rank + 1):end]
     return FeTerm{T,typeof(xfr)}(xfr, xrd, pivot, rank, cnms[pivot])

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -174,15 +174,14 @@ function LinearMixedModel(
     Xy = FeMat(feterm, vec(y))
     # Replace feterm's fullrankx field with a view into the shared Xymat storage,
     # eliminating the duplicate allocation for the full-rank X columns.
-    let rnk = feterm.rank, xview = view(Xy.xy, :, 1:rnk)
-        feterm = FeTerm{T,typeof(xview)}(
+    xview = view(Xy.xy, :, 1:feterm.rank)
+    feterm = FeTerm{T,typeof(xview)}(
             xview,
             getfield(feterm, :xrankdef),
             feterm.piv,
             feterm.rank,
             feterm.cnames,
-        )
-    end
+    )
     sqrtwts = map!(sqrt, Vector{T}(undef, length(weights)), weights)
     reweight!.(reterms, Ref(sqrtwts))
     reweight!(Xy, sqrtwts)

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -176,11 +176,11 @@ function LinearMixedModel(
     # eliminating the duplicate allocation for the full-rank X columns.
     xview = view(Xy.xy, :, 1:(feterm.rank))
     feterm = FeTerm{T,typeof(xview)}(
-            xview,
-            getfield(feterm, :xrankdef),
-            feterm.piv,
-            feterm.rank,
-            feterm.cnames,
+        xview,
+        getfield(feterm, :xrankdef),
+        feterm.piv,
+        feterm.rank,
+        feterm.cnames,
     )
     sqrtwts = map!(sqrt, Vector{T}(undef, length(weights)), weights)
     reweight!.(reterms, Ref(sqrtwts))

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -174,7 +174,7 @@ function LinearMixedModel(
     Xy = FeMat(feterm, vec(y))
     # Replace feterm's fullrankx field with a view into the shared Xymat storage,
     # eliminating the duplicate allocation for the full-rank X columns.
-    xview = view(Xy.xy, :, 1:feterm.rank)
+    xview = view(Xy.xy, :, 1:(feterm.rank))
     feterm = FeTerm{T,typeof(xview)}(
             xview,
             getfield(feterm, :xrankdef),

--- a/src/linearmixedmodel.jl
+++ b/src/linearmixedmodel.jl
@@ -7,8 +7,8 @@ Linear mixed-effects model representation
 
 * `formula`: the formula for the model
 * `reterms`: a `Vector{AbstractReMat{T}}` of random-effects terms.
-* `Xymat`: horizontal concatenation of a full-rank fixed-effects model matrix `X` and response `y` as an `FeMat{T}`
-* `feterm`: the fixed-effects model matrix as an `FeTerm{T}`
+* `Xymat`: horizontal concatenation of the full-rank fixed-effects model matrix `X` and response `y` as an `FeMat{T}`
+* `feterm`: the fixed-effects model matrix as an `FeTerm{T}`. For full-rank models, `feterm`'s internal `fullrankx` field is a view into the first `p` columns of `Xymat.xy`, so both share the same backing allocation.
 * `sqrtwts`: vector of square roots of the case weights.  Can be empty.
 * `parmap` : Vector{NTuple{3,Int}} of (block, row, column) mapping of θ to λ
 * `dims` : NamedTuple{(:n, :p, :nretrms),NTuple{3,Int}} of dimensions.  `p` is the rank of `X`, which may be smaller than `size(X, 2)`.
@@ -172,6 +172,17 @@ function LinearMixedModel(
 
     sort!(reterms; by=nranef, rev=true)
     Xy = FeMat(feterm, vec(y))
+    # Replace feterm's fullrankx field with a view into the shared Xymat storage,
+    # eliminating the duplicate allocation for the full-rank X columns.
+    let rnk = feterm.rank, xview = view(Xy.xy, :, 1:rnk)
+        feterm = FeTerm{T,typeof(xview)}(
+            xview,
+            getfield(feterm, :xrankdef),
+            feterm.piv,
+            feterm.rank,
+            feterm.cnames,
+        )
+    end
     sqrtwts = map!(sqrt, Vector{T}(undef, length(weights)), weights)
     reweight!.(reterms, Ref(sqrtwts))
     reweight!(Xy, sqrtwts)

--- a/src/mixedmodel.jl
+++ b/src/mixedmodel.jl
@@ -113,10 +113,17 @@ StatsAPI.meanresponse(m::MixedModel) = mean(m.y)
 
 Returns the model matrix `X` for the fixed-effects parameters, as returned by [`coef`](@ref).
 
-This is always the full model matrix in the original column order and from a field in the model
-struct.  It should be copied if it is to be modified.
+This always allocates a copy. For full-rank models it copies from shared internal storage;
+for rank-deficient models it reconstructs the full pivoted matrix from stored parts.
+
+See also [`fullrankx`](@ref).
 """
-StatsAPI.modelmatrix(m::MixedModel) = m.feterm.x
+function StatsAPI.modelmatrix(m::MixedModel)
+    fe = m.feterm
+    xfr = getfield(fe, :fullrankx)
+    xrd = getfield(fe, :xrankdef)
+    return isempty(xrd) ? copy(xfr) : hcat(xfr, xrd)
+end
 
 StatsAPI.nobs(m::MixedModel) = length(m.y)
 

--- a/test/matrixterm.jl
+++ b/test/matrixterm.jl
@@ -19,6 +19,25 @@ include("modelcache.jl")
     MixedModels.reweight!(mat, wts)
     @test mul!(prd, mat', mat)[ipiv[1], ipiv[1]] ≈ sum(abs2, wts)
 
+    # propertynames: public view hides internal fields
+    trm2 = MixedModels.FeTerm(hcat(ones(30), repeat(0:9; outer=3)), ["(Intercept)", "U"])
+    @test propertynames(trm2) == (:x, :piv, :rank, :cnames)
+    @test :fullrankx ∈ propertynames(trm2, true)
+    @test :xrankdef ∈ propertynames(trm2, true)
+
+    # copyto! writes into the fullrankx storage
+    src = zeros(30, 2)
+    copyto!(trm2, src)
+    @test all(iszero, getfield(trm2, :fullrankx))
+
+    # copyto! on a linked feterm (fullrankx is a view into Xymat.xy) writes through
+    m = first(models(:sleepstudy))
+    old_x = copy(getfield(m.feterm, :fullrankx))
+    src_m = zeros(size(old_x))
+    copyto!(m.feterm, src_m)
+    @test all(iszero, m.Xymat.xy[:, 1:(m.feterm.rank)])
+    copyto!(m.feterm, old_x)  # restore
+
     # empty fixed effects
     trm = MixedModels.FeTerm(ones(10, 0), String[])
     #@test size(trm) == (10, 0)  # There no longer are size and length methods for FeTerm

--- a/test/pivot.jl
+++ b/test/pivot.jl
@@ -4,7 +4,7 @@ import MixedModels: statsrank
 
 xtx(X) = Symmetric(X'X, :U)  # creat the symmetric matrix X'X from X
 # this is defined in Julia 1.13
-@static if VERSION < v"1.13.0-DEV.655"
+@static if !hasmethod(LinearAlgebra.rank, (LinearAlgebra.QRPivoted,))
     function LinearAlgebra.rank(F::LinearAlgebra.QRPivoted; tol=1e-8)
         return searchsortedlast(abs.(diag(F.R)), tol; rev=true)
     end


### PR DESCRIPTION
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.
- [x] I've bumped the version appropriately
