### PR TITLE
Faster rankUpdate! method for HermitianRFP

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,13 @@
 MixedModels v5.8.1 Release Notes
 ==============================
 - Performance improvements for RFP-matrices. [#910]
+- The sparse `rankUpdate!` of a densely stored diagonal block of `L` now walks the `colptr` of the update directly and indexes the block linearly, matching the structure of the RFP kernel. This hoists the column offset out of the inner loop and removes a level of indirection, for roughly a 15% speedup of that kernel. [#910]
 
 MixedModels v5.8.0 Release Notes
 ==============================
 - Allow for diagonal blocks of `L` to be stored in `RectangularFullPacked` (RFP) format, which saves roughly half the storage required for the block.  This can increase the time required for `updateL!`, primarily in the `rankUpdate!` step, resulting in a time vs. memory tradeoff.  The size threshold for RFP storage is a new optional argument `RFPthreshold`, which defaults to 1000.
 - The RFP format stores a triangular matrix in two pieces: a trapezoidal part of roughly 3/4 of the elements, where linear indexing can be used for the updates, and a transposed triangular part with more complicated `getindex` and `setindex!` methods.
-- A new Boolean optional argument, `sortlevels`, which defaults to `true`, allows for sorting the levels of the any grouping factors with RFP storage of their diagonal blocks.  This is a heuristic to have more updates occur in the trapezoid part of the RFP block.  It is not guaranteed to be optimal but it works well in examples we have tried. [#821]
+- A new Boolean optional argument, `sortlevels`, which defaults to `true`, sorts the levels of each grouping factor other than the leading one by decreasing number of occurrences.  This applies to both dense and RFP storage of the diagonal blocks of `L`: placing the most frequent levels first concentrates the sparse `rankUpdate!` of a block in a compact corner of its storage, which improves memory locality.  For RFP storage it additionally keeps more of those updates in the trapezoid part of the block.  This is a heuristic, not guaranteed to be optimal, but it works well in examples we have tried. [#821]
 
 MixedModels v5.7.1 Release Notes
 ==============================

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,9 @@
 MixedModels v5.8.1 Release Notes
 ==============================
-- Performance improvements for RFP-matrices. [#910]
-- The sparse `rankUpdate!` of a densely stored diagonal block of `L` now walks the `colptr` of the update directly and indexes the block linearly, matching the structure of the RFP kernel. This hoists the column offset out of the inner loop and removes a level of indirection, for roughly a 15% speedup of that kernel. [#910]
+- The sparse `rankUpdate!` of a diagonal block of `L` has been reworked, for both RFP and dense storage of the block.  Rather than going through `nzrange` and indexing into the resulting range, both kernels now walk the `colptr` of the update directly, carrying a running index into `rowval` and `nzval`.  This removes a level of indirection from the inner loops and hoists the offset of the target column out of them. [#910]
+- In the RFP kernel, the per-element assertion that row indices are sorted within a column has been replaced by a single `issorted` check per column.  That check is what makes the inner loops safe to mark `@inbounds`, and performing it once per column is far cheaper than once per element of the quadratic inner loops. [#910]
+- Relative to v5.8.0, the RFP kernel is roughly 1.65× faster on `insteval` and 1.1× faster on an example too large for cache, which closes most of the gap between RFP and dense storage noted below: on `insteval` the RFP update went from about 60% slower than the dense one to under 10% slower.  The dense kernel itself gains about 15% when the block fits in cache and little when it does not. [#910]
+- `rankUpdate!` on a `HermitianRFP` that is not in lower, non-transposed storage now reports the offending `transr` and `uplo` in the `ArgumentError`. [#910]
 
 MixedModels v5.8.0 Release Notes
 ==============================

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v5.8.1 Release Notes
+==============================
+- Performance improvements for RFP-matrices. [#910]
+
 MixedModels v5.8.0 Release Notes
 ==============================
 - Allow for diagonal blocks of `L` to be stored in `RectangularFullPacked` (RFP) format, which saves roughly half the storage required for the block.  This can increase the time required for `updateL!`, primarily in the `rankUpdate!` step, resulting in a time vs. memory tradeoff.  The size threshold for RFP storage is a new optional argument `RFPthreshold`, which defaults to 1000.
@@ -783,3 +787,4 @@ Package dependencies
 [#898]: https://github.com/JuliaStats/MixedModels.jl/issues/898
 [#899]: https://github.com/JuliaStats/MixedModels.jl/issues/899
 [#904]: https://github.com/JuliaStats/MixedModels.jl/issues/904
+[#910]: https://github.com/JuliaStats/MixedModels.jl/issues/910

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>"]
-version = "5.8.0"
+version = "5.8.1"
 
 [workspace]
 projects = ["docs"]

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -76,6 +76,60 @@ function _columndot(rv, nz, rngi, rngj)
     return accum
 end
 
+"""
+    _lowerrankUpdate!(Cd, A, α)
+
+Add `α * A * A'` to the lower triangle of `Cd`, where `A` is a `SparseMatrixCSC`.
+
+Each column of `A` contributes the outer product of its nonzeros.  Because `rowval` is
+sorted within a column, walking from a given entry to the end of its column visits exactly
+the rows `i ≥ j` of the lower triangle.
+"""
+function _lowerrankUpdate!(Cd::AbstractMatrix{T}, A::SparseMatrixCSC{T}, α) where {T}
+    rv, nz = A.rowval, A.nzval
+    @inbounds for jj in axes(A, 2)
+        rangejj = nzrange(A, jj)
+        lenrngjj = length(rangejj)
+        for (k, j) in enumerate(rangejj)
+            anzj = α * nz[j]
+            rvj = rv[j]
+            for i in k:lenrngjj
+                kk = rangejj[i]
+                Cd[rv[kk], rvj] = muladd(nz[kk], anzj, Cd[rv[kk], rvj])
+            end
+        end
+    end
+    return Cd
+end
+
+# A dense `Cd` is contiguous and column-major, so the column offset can be hoisted out of the
+# inner loop and the two `rowval` lookups collapsed to one linear index, as in the
+# `HermitianRFP` kernel below.  Unlike that kernel, this one needs no sortedness `@assert` to
+# justify its `@inbounds`: `rowval` entries lie in `1:size(A, 1) == 1:size(Cd, 1)`, so
+# `offset + rowval[indi]` is within `1:length(Cd)` no matter how the rows are ordered.
+# Sortedness is what confines the writes to the lower triangle, exactly as in the method above.
+function _lowerrankUpdate!(Cd::DenseMatrix{T}, A::SparseMatrixCSC{T}, α) where {T}
+    (; colptr, rowval, nzval) = A
+    Cdm = size(Cd, 1)
+    indj = 1
+    # each colp is one past the last rowval/nzval index of the preceding column of A
+    for colp in colptr
+        while indj < colp                     # first iteration skipped b/c colptr[1] is always 1
+            j = Int(rowval[indj])             # column of Cd to be updated
+            anzj = α * nzval[indj]
+            offset = (j - 1) * Cdm            # offset to col j for linear indices into Cd
+            indi = indj
+            @inbounds while indi < colp       # iterate over the rest of the column of A
+                linind = offset + Int(rowval[indi])
+                Cd[linind] = muladd(nzval[indi], anzj, Cd[linind])
+                indi += 1
+            end
+            indj += 1
+        end
+    end
+    return Cd
+end
+
 function rankUpdate!(
     C::HermOrSym{T,S},
     A::SparseMatrixCSC{T},
@@ -93,22 +147,12 @@ function rankUpdate!(
         )
     end
 
-    Cd, rv, nz = C.data, A.rowval, A.nzval
+    Cd = C.data
     isone(β) || rmul!(lower ? LowerTriangular(Cd) : UpperTriangular(Cd), β)
     if lower
-        @inbounds for jj in axes(A, 2)
-            rangejj = nzrange(A, jj)
-            lenrngjj = length(rangejj)
-            for (k, j) in enumerate(rangejj)
-                anzj = α * nz[j]
-                rvj = rv[j]
-                for i in k:lenrngjj
-                    kk = rangejj[i]
-                    Cd[rv[kk], rvj] = muladd(nz[kk], anzj, Cd[rv[kk], rvj])
-                end
-            end
-        end
+        _lowerrankUpdate!(Cd, A, α)
     else
+        rv, nz = A.rowval, A.nzval
         @inbounds for j in axes(C, 2)
             rngj = nzrange(A, j)
             for i in 1:(j - 1)

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -148,7 +148,7 @@ function rankUpdate!(
             if j ≤ Cdn                        # in the trapezoidal part of Cdat (most common case)
                 offset = (j - 1) * Cdm + tall # offset to col j for linear indices into Cdat
                 indi = indj
-                while indi < colp             # iterate over the rest of the column of A
+                @inbounds while indi < colp   # iterate over the rest of the column of A
                     linind = offset + Int(rowval[indi])
                     Cdat[linind] = muladd(nzval[indi], anzj, Cdat[linind])
                     indi += 1

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -128,7 +128,11 @@ function rankUpdate!(
 ) where {T}
     require_one_based_indexing(C, A)
     if uppercase(C.transr) ≠ 'N' || uppercase(C.uplo) ≠ 'L'
-        throw(ArgumentError("HermitianRFP C is not lower, non-transposed storage"))
+        throw(
+            ArgumentError(
+                "HermitianRFP C must be lower, non-transposed storage; got transr='$(C.transr)', uplo='$(C.uplo)'"
+            ),
+        )
     end
     (; m, colptr, rowval, nzval) = A
     Cdat = C.data

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -141,7 +141,7 @@ function rankUpdate!(
     end
     tall = iseven(m)                          # is Cdat in the tall (vs wide) format?
     Cdm, Cdn = size(Cdat)
-    # the @inbounds inner loop below is only in-bounds because Cdm == m + tall, so this
+    # the @inbounds inner loops below are only in-bounds because Cdm == m + tall, so this
     # check must stay
     @assert (Cdm == m + tall) && (Cdn == ((m + !tall) >> 1))
 
@@ -149,6 +149,10 @@ function rankUpdate!(
     indj = 1
     # each colp is one past the last rowval/nzval index of the preceding column of A
     for colp in colptr
+        # Both inner loops start at indj and so require i ≥ j, i.e. sorted rowval within a
+        # column, which is the SparseMatrixCSC contract.  Checking it once per column is
+        # cheaper than the O(len^2) inner loops and is what makes their @inbounds safe.
+        @assert issorted(view(rowval, indj:(colp - 1)))
         while indj < colp                     # first iteration skipped b/c colptr[1] is always 1
             j = Int(rowval[indj])             # column in C to be updated
             anzj = α * nzval[indj]
@@ -163,7 +167,7 @@ function rankUpdate!(
             else                              # in the transposed triangular part of Cdat
                 Cdrow = j - Cdn               # row in triangular part of Cdat for col j
                 indi = indj
-                while indi < colp
+                @inbounds while indi < colp   # iterate over the rest of the column of A
                     i = Int(rowval[indi])
                     linind = (i - Cdn - tall) * Cdm + Cdrow
                     Cdat[linind] = muladd(nzval[indi], anzj, Cdat[linind])

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -141,11 +141,14 @@ function rankUpdate!(
     end
     tall = iseven(m)                          # is Cdat in the tall (vs wide) format?
     Cdm, Cdn = size(Cdat)
-    @assert (Cdm == m + tall) && (Cdn == ((m + !tall) >> 1)) # can suppress this later
+    # the @inbounds inner loop below is only in-bounds because Cdm == m + tall, so this
+    # check must stay
+    @assert (Cdm == m + tall) && (Cdn == ((m + !tall) >> 1))
 
     isone(β) || rmul!(Cdat, β)
     indj = 1
-    for colp in colptr                        # (max index + 1) in rowval, nzval for a column of A
+    # each colp is one past the last rowval/nzval index of the preceding column of A
+    for colp in colptr
         while indj < colp                     # first iteration skipped b/c colptr[1] is always 1
             j = Int(rowval[indj])             # column in C to be updated
             anzj = α * nzval[indj]
@@ -158,7 +161,7 @@ function rankUpdate!(
                     indi += 1
                 end
             else                              # in the transposed triangular part of Cdat
-                Cdrow = j - Cdn               # row in triangular part of Cdat for col j  
+                Cdrow = j - Cdn               # row in triangular part of Cdat for col j
                 indi = indj
                 while indi < colp
                     i = Int(rowval[indi])

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -128,14 +128,14 @@ function rankUpdate!(
 ) where {T}
     require_one_based_indexing(C, A)
     if uppercase(C.transr) ≠ 'N' || uppercase(C.uplo) ≠ 'L'
-        throw(ArgumentError("HermitianRFP C is not non-trans, lower"))
+        throw(ArgumentError("HermitianRFP C is not lower, non-transposed storage"))
     end
     (; m, colptr, rowval, nzval) = A
     Cdat = C.data
     if m ≠ size(C, 1)
         throw(DimensionMismatch("size(A, 1) == $m ≠ $(size(C, 1)) = size(C, 1)"))
     end
-    tall = iseven(m)                           # is Cdat in the tall (vs wide) format?
+    tall = iseven(m)                          # is Cdat in the tall (vs wide) format?
     Cdm, Cdn = size(Cdat)
     @assert (Cdm == m + tall) && (Cdn == ((m + !tall) >> 1)) # can suppress this later
 

--- a/src/linalg/rankUpdate.jl
+++ b/src/linalg/rankUpdate.jl
@@ -130,40 +130,40 @@ function rankUpdate!(
     if uppercase(C.transr) ≠ 'N' || uppercase(C.uplo) ≠ 'L'
         throw(ArgumentError("HermitianRFP C is not non-trans, lower"))
     end
-    rv, nz = A.rowval, A.nzval
+    (; m, colptr, rowval, nzval) = A
     Cdat = C.data
-    An = size(A, 1)
-    if An ≠ size(C, 1)
-        throw(DimensionMismatch("size(A, 1) == $An ≠ $(size(C, 1)) = size(C, 1)"))
+    if m ≠ size(C, 1)
+        throw(DimensionMismatch("size(A, 1) == $m ≠ $(size(C, 1)) = size(C, 1)"))
     end
-    tall = iseven(An)        # is Cdat in the tall format or the wide format?
-    Cdn, Cdm = size(Cdat)
-    @assert (Cdn == An + tall) && (Cdm == ((An + !tall) >> 1))
+    tall = iseven(m)                           # is Cdat in the tall (vs wide) format?
+    Cdm, Cdn = size(Cdat)
+    @assert (Cdm == m + tall) && (Cdn == ((m + !tall) >> 1)) # can suppress this later
 
     isone(β) || rmul!(Cdat, β)
-    for jj in axes(A, 2)
-        rngjj = nzrange(A, jj)
-        lenrngjj = length(rngjj)
-        for (k, j) in enumerate(rngjj)
-            anzj = α * nz[j]
-            rvj = rv[j]                         # updates in rvj column of C
-            if rvj ≤ Cdm                        # in the trapezoidal part of Cdat
-                offset = (rvj - 1) * Cdn + tall
-                for i in k:lenrngjj
-                    kk = rngjj[i]
-                    linind = offset + rv[kk]
-                    Cdat[linind] = muladd(nz[kk], anzj, Cdat[linind])
+    indj = 1
+    for colp in colptr                        # (max index + 1) in rowval, nzval for a column of A
+        while indj < colp                     # first iteration skipped b/c colptr[1] is always 1
+            j = Int(rowval[indj])             # column in C to be updated
+            anzj = α * nzval[indj]
+            if j ≤ Cdn                        # in the trapezoidal part of Cdat (most common case)
+                offset = (j - 1) * Cdm + tall # offset to col j for linear indices into Cdat
+                indi = indj
+                while indi < colp             # iterate over the rest of the column of A
+                    linind = offset + Int(rowval[indi])
+                    Cdat[linind] = muladd(nzval[indi], anzj, Cdat[linind])
+                    indi += 1
                 end
-            else                                # in the transposed triangular part of Cdat
-                Cdrow = rvj - Cdm
-                for i in k:lenrngjj
-                    kk = rngjj[i]
-                    rvkk = rv[kk]
-                    @assert rvkk ≥ rvj
-                    linind = (rvkk - Cdm - tall) * Cdn + Cdrow
-                    Cdat[linind] = muladd(nz[kk], anzj, Cdat[linind])
+            else                              # in the transposed triangular part of Cdat
+                Cdrow = j - Cdn               # row in triangular part of Cdat for col j  
+                indi = indj
+                while indi < colp
+                    i = Int(rowval[indi])
+                    linind = (i - Cdn - tall) * Cdm + Cdrow
+                    Cdat[linind] = muladd(nzval[indi], anzj, Cdat[linind])
+                    indi += 1
                 end
             end
+            indj += 1
         end
     end
     return C

--- a/test/RFP.jl
+++ b/test/RFP.jl
@@ -4,6 +4,8 @@ using Test
 using SparseArrays
 using RectangularFullPacked
 
+using MixedModels: rankUpdate!
+
 # tests of the rankUpdate! method when `typeof(C)` is `HermitianRFP`
 @testset "rankUpHermitianRFP" begin
     A9 = float(sprand(Bool, 9, 12, 0.3))

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -72,6 +72,17 @@ end
     L22L = rankUpdate!(Symmetric(zeros(100, 100), :L), L21, 1.0, 1.0)
     @test L22L ≈
         rankUpdate!(Symmetric(zeros(100, 100), :U), sparse(transpose(L21)), 1.0, 1.0)
+
+    # The lower-triangle update has a fast path for dense `C.data`, which indexes linearly,
+    # and a generic fallback.  A `SubArray` is not a `DenseMatrix`, so it takes the fallback;
+    # both paths accumulate in the same order, hence the results agree exactly.
+    @test rankUpdate!(Symmetric(view(zeros(100, 100), :, :), :L), L21, 1.0, 1.0) == L22L
+    # β ≠ 1 scales the stored triangle first, on either path
+    @test rankUpdate!(Symmetric(Matrix(L22L), :L), L21, 1.0, 2.0) ==
+        rankUpdate!(Symmetric(view(Matrix(L22L), :, :), :L), L21, 1.0, 2.0)
+    # Int32 row indices, as produced by `sparse(::BlockedSparse)`
+    L21_32 = convert(SparseMatrixCSC{Float64,Int32}, L21)
+    @test rankUpdate!(Symmetric(zeros(100, 100), :L), L21_32, 1.0, 1.0) == L22L
 end
 
 @testset "rankUpdate! HermitianRFP" begin

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -117,6 +117,14 @@ end
     upper = Hermitian(TriangularRFP(Matrix(UpperTriangular(S)), :U), :U)
     @test_throws ArgumentError rankUpdate!(upper, sprand(rng, 6, 4, 0.5), 1.0, 1.0)
     @test_throws DimensionMismatch rankUpdate!(rfp(S), sprand(rng, 5, 4, 0.5), 1.0, 1.0)
+
+    # rowval must be sorted within a column, since both inner loops start at indj and so
+    # assume i ≥ j.  For n = 6 the packed array has 3 columns, putting row 3 in the
+    # trapezoidal branch and row 4 in the triangular one; either way this must be caught.
+    for rows in ([3, 1], [4, 2])
+        unsorted = SparseMatrixCSC(6, 1, [1, 3], rows, ones(2))
+        @test_throws AssertionError rankUpdate!(rfp(S), unsorted, 1.0, 1.0)
+    end
 end
 
 #=  I don't see this testset as meaningful b/c diagonal A does not occur after amalgamation of ReMat's for the same grouping factor - D.B.

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -76,17 +76,8 @@ end
 
 @testset "rankUpdate! HermitianRFP" begin
     rng = MersenneTwister(1234)
-    n = 6
-
-    # a symmetric, lower-stored base matrix and the packed HermitianRFP holding it
-    S = let M = randn(rng, n, n)
-        M * M' + n * I
-    end
     rfp(S) = Hermitian(TriangularRFP(Matrix(LowerTriangular(S)), :L), :L)
 
-    # dense and (Int32) sparse updates plus a genuine BlockedSparse block
-    Adense = randn(rng, n, 4)
-    Asparse = convert(SparseMatrixCSC{Float64,Int32}, sparse(sprand(rng, n, 20, 0.3)))
     # crossed factors ⇒ an off-diagonal L block stored as BlockedSparse
     d3 = MixedModels.dataset(:d3)
     m = fit!(
@@ -97,7 +88,20 @@ end
     @test Ablk isa BlockedSparse
     Sblk = zeros(size(Ablk, 1), size(Ablk, 1)) + I
 
-    for (A, base) in ((Adense, S), (Asparse, S), (Ablk, Sblk))
+    testcases = Any[(Ablk, Sblk)]
+    # both parities of n are needed: even n packs into the tall RFP layout, odd n the wide one
+    for n in (6, 7)
+        # a symmetric, lower-stored base matrix and the packed HermitianRFP holding it
+        S = let M = randn(rng, n, n)
+            M * M' + n * I
+        end
+        # dense and (Int32) sparse updates
+        push!(testcases, (randn(rng, n, 4), S))
+        Asparse = convert(SparseMatrixCSC{Float64,Int32}, sparse(sprand(rng, n, 20, 0.3)))
+        push!(testcases, (Asparse, S))
+    end
+
+    for (A, base) in testcases
         for (α, β) in ((1.0, 1.0), (-1.0, 1.0), (0.5, 2.0))
             ref = rankUpdate!(Hermitian(Matrix(base), :L), A, α, β)
             got = rankUpdate!(rfp(base), A, α, β)
@@ -105,6 +109,14 @@ end
             @test LowerTriangular(Matrix(got)) ≈ LowerTriangular(Matrix(ref))
         end
     end
+
+    # the sparse kernel only handles lower, non-transposed storage of a matching size
+    S = let M = randn(rng, 6, 6)
+        M * M' + 6I
+    end
+    upper = Hermitian(TriangularRFP(Matrix(UpperTriangular(S)), :U), :U)
+    @test_throws ArgumentError rankUpdate!(upper, sprand(rng, 6, 4, 0.5), 1.0, 1.0)
+    @test_throws DimensionMismatch rankUpdate!(rfp(S), sprand(rng, 5, 4, 0.5), 1.0, 1.0)
 end
 
 #=  I don't see this testset as meaningful b/c diagonal A does not occur after amalgamation of ReMat's for the same grouping factor - D.B.


### PR DESCRIPTION
- Rewrite the `rankUpdate!(C::HermitianRFP{T}, A::SparseMatrixCSC{T}, ...)` method to use `A.colptr` directly and avoid calls to `nzrange(A, j)` which just add another layer of indirection.
- As part of this rewrite the levels of the second grouping factor are sorted by decreasing incidence when the reterm is generated.  This concentrates more of the updates in the trapezoidal storage of `C.data` where linear indexing can be used.
