### PR TITLE
stop using the deprecated `wts` in favor or `weights` in tests

### DIFF
--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -72,7 +72,7 @@ end
             first(gfms[:cbpp]),
             cbpp,
             Binomial();
-            wts=float(cbpp.hsz),
+            weights=float(cbpp.hsz),
             progress=false,
         )
         gm2sim = refit!(simulate!(StableRNG(42), deepcopy(gm2)); fast=true, progress=false)

--- a/test/bootstrap.jl
+++ b/test/bootstrap.jl
@@ -276,13 +276,13 @@ end
                 return b != c
             end
 
-            m = LinearMixedModel(@formula(y ~ 1 + b * c + (1 | id)), df)
+            m = @suppress LinearMixedModel(@formula(y ~ 1 + b * c + (1 | id)), df)
             β = 1:rank(m)
             σ = 1
             simulate!(StableRNG(628), m; β, σ)
             fit!(m)
 
-            boot = parametricbootstrap(StableRNG(271828), 1000, m)
+            boot = parametricbootstrap(StableRNG(271828), 1000, m; progress=false)
             bootci = DataFrame(shortestcovint(boot))
             filter!(:group => ismissing, bootci)
             select!(bootci, :names => disallowmissing => :coef, :lower, :upper)

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -68,7 +68,7 @@ using Test
             0.172018349,
         ],
     )
-    m2 = lmm(@formula(a ~ 1 + b + (1 | c)), data; wts=data.w1, progress=false)
+    m2 = lmm(@formula(a ~ 1 + b + (1 | c)), data; weights=data.w1, progress=false)
     @test m2.θ ≈ [0.295181729258352] atol = 1.e-4
     @test stderror(m2) ≈ [0.9640167, 3.6309696] atol = 1.e-4
     @test vcov(m2) ≈ [0.9293282 -2.557527; -2.5575267 13.183940] atol = 1.e-4

--- a/test/likelihoodratiotest.jl
+++ b/test/likelihoodratiotest.jl
@@ -20,18 +20,18 @@ include("modelcache.jl")
     # mismatched RE terms
     m1 = LinearMixedModel(@formula(reaction ~ 1 + days + (1 + days | subj)), slp)
     m2 = LinearMixedModel(@formula(reaction ~ 1 + days + (0 + days | subj)), slp)
-    @test !isnested(m1, m2)
+    @test @suppress !isnested(m1, m2)
 
     # mismatched FE
     m1 = LinearMixedModel(@formula(reaction ~ 1 + days + (1 | subj)), slp)
     m2 = LinearMixedModel(@formula(reaction ~ 0 + days + (1 | subj)), slp)
-    @test !isnested(m1, m2)
+    @test @suppress !isnested(m1, m2)
 
     # mismatched grouping vars
     kb07 = dataset(:kb07)
     m1 = LinearMixedModel(@formula(rt_trunc ~ 1 + (1 | subj)), kb07)
     m2 = LinearMixedModel(@formula(rt_trunc ~ 1 + (1 | item)), kb07)
-    @test !isnested(m1, m2)
+    @test @suppress !isnested(m1, m2)
 
     # fixed-effects specification in REML and
     # conversion of internal ArgumentError into @error for StatsModels.isnested

--- a/test/linalg.jl
+++ b/test/linalg.jl
@@ -52,7 +52,7 @@ end
         MixedModel,
         @formula(Y ~ 1 + A + (1 + A | G) + (1 + A | H)),
         df;
-        wts=ones(400),
+        weights=ones(400),
         progress=false,
     )
     @test loglikelihood(wm1) ≈ loglikelihood(m1)

--- a/test/pirls.jl
+++ b/test/pirls.jl
@@ -129,7 +129,7 @@ end
         first(gfms[:cbpp]),
         cbpp,
         Binomial();
-        wts=float(cbpp.hsz),
+        weights=float(cbpp.hsz),
         progress=false,
         init_from_lmm=[:β, :θ],
     )
@@ -171,7 +171,7 @@ end
         # we do construction and fitting in two separate steps to make sure
         # that construction succeeds and that the ArgumentError occurs in fitting.
         mcbconst = GeneralizedLinearMixedModel(
-            first(gfms[:cbpp]), cbconst, Binomial(); wts=float(cbpp.hsz)
+            first(gfms[:cbpp]), cbconst, Binomial(); weights=float(cbpp.hsz)
         )
         @test mcbconst isa GeneralizedLinearMixedModel
         @test_throws ArgumentError(
@@ -303,10 +303,10 @@ end
 @testset "GLMM saveoptsum" begin
     cbpp = dataset(:cbpp)
     gm_original = GeneralizedLinearMixedModel(
-        first(gfms[:cbpp]), cbpp, Binomial(); wts=cbpp.hsz
+        first(gfms[:cbpp]), cbpp, Binomial(); weights=cbpp.hsz
     )
     gm_restored = GeneralizedLinearMixedModel(
-        first(gfms[:cbpp]), cbpp, Binomial(); wts=cbpp.hsz
+        first(gfms[:cbpp]), cbpp, Binomial(); weights=cbpp.hsz
     )
     fit!(gm_original; progress=false, nAGQ=1)
 

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -971,7 +971,7 @@ end
     @test vcov(m1) ≈ [1.177034697250409 -4.80259802739442; -4.80259802739442 24.66449662452017] atol = 1.e-4
     =#
 
-    m2 = fit(MixedModel, @formula(a ~ 1 + b + (1 | c)), data; wts=data.w1, progress=false)
+    m2 = fit(MixedModel, @formula(a ~ 1 + b + (1 | c)), data; weights=data.w1, progress=false)
     @test m2.θ ≈ [0.2951818091809752] atol = 1.e-4
     @test stderror(m2) ≈ [0.964016663994572, 3.6309691484830533] atol = 1.e-4
     @test vcov(m2) ≈

--- a/test/pls.jl
+++ b/test/pls.jl
@@ -184,7 +184,7 @@ end
     @test objective(fm) ≈ 327.32705988112673 atol = 0.001
     refit!(fm, float(MixedModels.dataset(:dyestuff2)[:yield]); progress=false) # restore the model in the cache
     @testset "profile" begin   # tests a branch in profileσs! for σ estimate of zero
-        dspr02 = profile(only(models(:dyestuff2)))
+        dspr02 = @suppress profile(only(models(:dyestuff2)))
         sigma10row = only(filter(r -> r.p == :σ1 && iszero(r.ζ), dspr02.tbl))
         @test iszero(sigma10row.σ1)
         sigma1tbl = Table(filter(r -> r.p == :σ1, dspr02.tbl))
@@ -604,26 +604,26 @@ end
         # try it out with an empty fitlog
         empty!(fm.optsum.fitlog)
         saveoptsum(seekstart(io), fm)
-        restoreoptsum!(m, seekstart(io))
+        @suppress restoreoptsum!(m, seekstart(io))
         # the restored fitlog always contains the initial and final values
         @test length(m.optsum.fitlog) == 2
 
         fm_mod = deepcopy(fm)
         fm_mod.optsum.fmin += 1
         saveoptsum(seekstart(io), fm_mod)
-        @test_throws(
+        @suppress @test_throws(
             ArgumentError(
                 "model at final does not match stored fmin within atol=0.0, rtol=1.0e-8"
             ),
             restoreoptsum!(m, seekstart(io); atol=0.0, rtol=1e-8))
-        restoreoptsum!(m, seekstart(io); atol=1)
+        @suppress restoreoptsum!(m, seekstart(io); atol=1)
         @test m.optsum.fmin - fm.optsum.fmin ≈ 1
 
         # using a temporary file for saving JSON
         fnm = first(mktemp())
         saveoptsum(fnm, fm)
         m = LinearMixedModel(fm.formula, MixedModels.dataset(:sleepstudy))
-        restoreoptsum!(m, fnm)
+        @suppress restoreoptsum!(m, fnm)
         @test loglikelihood(fm) ≈ loglikelihood(m)
         @test bic(fm) ≈ bic(m)
         @test coef(fm) ≈ coef(m)

--- a/test/predict.jl
+++ b/test/predict.jl
@@ -178,7 +178,7 @@ end
             )
             @test m_nonpiv.feterm.rank == 2
             @test m_nonpiv.feterm.piv == [2, 3, 1]
-            @test predict(m_nonpiv, df_nonpiv) ≈ fitted(m_nonpiv)
+            @test @suppress(predict(m_nonpiv, df_nonpiv)) ≈ fitted(m_nonpiv)
         end
     end
 

--- a/test/sigma.jl
+++ b/test/sigma.jl
@@ -52,7 +52,7 @@ end
 # @rget dat
 
 # fit(MixedModel, @formula(yi ~ 1 + (1 | study)), dat;
-#     wts=1 ./ dat.vi,
+#     weights=1 ./ dat.vi,
 #     REML=true,
 #     contrasts=Dict(:study => Grouping()),
 #     σ=1)


### PR DESCRIPTION
closes #908

Also adds a bunch of `@suppress` calls to hide other expected warnings during testing.