### PR TITLE
Allow users to specify custom coefficient values for `predict`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+MixedModels v5.9.0 Release Notes
+================================
+- `predict` now accepts a `β` keyword argument for supplying a custom fixed-effects coefficient vector instead of the model's own fitted estimates. As with `simulate!`, `β` may be given either as a pivoted, full-rank vector (cf. `fixef`) or an unpivoted, full-dimension vector (cf. `coef`), with entries for redundant columns ignored. The default behavior (using the model's own estimates) is unchanged. [#916]
+
 MixedModels v5.8.4 Release Notes
 ================================
 - Remove dependency in `docs/Project.toml` on `MixedModelsSerialization` which was holding up other package version updates. [#915]
@@ -807,3 +811,4 @@ Package dependencies
 [#910]: https://github.com/JuliaStats/MixedModels.jl/issues/910
 [#911]: https://github.com/JuliaStats/MixedModels.jl/issues/911
 [#915]: https://github.com/JuliaStats/MixedModels.jl/issues/915
+[#916]: https://github.com/JuliaStats/MixedModels.jl/issues/916

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModels"
 uuid = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 author = ["Phillip Alday <me@phillipalday.com>", "Douglas Bates <dmbates@gmail.com>"]
-version = "5.8.4"
+version = "5.9.0"
 
 [workspace]
 projects = ["docs"]

--- a/src/Xymat.jl
+++ b/src/Xymat.jl
@@ -127,6 +127,39 @@ Does `A` have full column rank?
 """
 isfullrank(A::FeTerm) = A.rank == length(A.piv)
 
+# Normalize a user-supplied fixed-effects coefficient vector `β` to a single
+# internal convention, accepting either of the two conventions documented for
+# `simulate!`: a pivoted, full-rank vector (cf. `fixef`, length `rank(m)`) or
+# an unpivoted, full-dimension vector (cf. `coef`, length `length(pivot(m))`),
+# the latter with any redundant-column entries ignored regardless of value.
+#
+# If `truncate`, the result has length `rank(m)` (for multiplying against
+# `fullrankx`); otherwise it has length `length(pivot(m))`, in pivoted order,
+# with entries beyond `rank(m)` set to zero (for multiplying against an
+# un-truncated, pivoted design matrix).
+function _pivotbeta(m::MixedModel{T}, β; truncate::Bool) where {T}
+    piv = pivot(m)
+    rnk = rank(m)
+    length(β) == length(piv) || length(β) == rnk ||
+        throw(ArgumentError("You must specify all (non-singular) βs"))
+
+    β = convert(Vector{T}, β)
+
+    if length(β) == length(piv)
+        βpiv = view(β, piv)
+        truncate && return view(βpiv, 1:rnk)
+        full = zeros(T, length(piv))
+        copyto!(view(full, 1:rnk), view(βpiv, 1:rnk))
+        return full
+    end
+
+    # β is already pivoted (and truncated to rank(m))
+    truncate && return β
+    full = zeros(T, length(piv))
+    copyto!(full, β)
+    return full
+end
+
 """
     FeMat{T,S}
 

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -79,7 +79,7 @@ Similarly, offsets are also not supported for `GeneralizedLinearMixedModel`.
 function StatsAPI.predict(
     m::LinearMixedModel, newdata::Tables.ColumnTable; new_re_levels=:missing, β=coef(m)
 )
-    return _predict(m, newdata, _pivotbeta(m, β); new_re_levels)
+    return _predict(m, newdata, _pivotbeta(m, β; truncate=false); new_re_levels)
 end
 
 function StatsAPI.predict(
@@ -91,7 +91,7 @@ function StatsAPI.predict(
 )
     type in (:linpred, :response) || throw(ArgumentError("Invalid value for type: $(type)"))
     # want pivoted but not truncated
-    y = _predict(m.LMM, newdata, _pivotbeta(m, β); new_re_levels)
+    y = _predict(m.LMM, newdata, _pivotbeta(m, β; truncate=false); new_re_levels)
 
     return type == :linpred ? y : broadcast!(Base.Fix1(linkinv, Link(m)), y, y)
 end
@@ -139,25 +139,6 @@ function _prediction_design(m::MixedModel{T}, newdata) where {T}
     _, Xs = modelcols(form, newdata)
     reterms, feterms = _split_re_fe_terms(Xs, form, T)
     return PredictionDesign{T}(only(feterms), reterms)
-end
-
-# normalize a user-supplied β (pivoted+truncated, cf. fixef, or unpivoted+full, cf. coef)
-# to the pivoted-but-not-truncated form that _predict expects, zeroing out any
-# redundant-column entries so that they're ignored regardless of their value
-function _pivotbeta(m::MixedModel{T}, β) where {T}
-    piv = pivot(m)
-    rnk = rank(m)
-    length(β) == length(piv) || length(β) == rnk ||
-        throw(ArgumentError("You must specify all (non-singular) βs"))
-    β = convert(Vector{T}, collect(β))
-    if length(β) == length(piv)
-        β = β[piv]
-        rnk == length(piv) || fill!(view(β, (rnk + 1):length(piv)), zero(T))
-        return β
-    end
-    full = zeros(T, length(piv))
-    copyto!(full, β)
-    return full
 end
 
 # β is separated out here because m.β != m.LMM.β depending on how β is estimated for GLMM

--- a/src/predict.jl
+++ b/src/predict.jl
@@ -1,8 +1,8 @@
 """
     StatsAPI.predict(m::LinearMixedModel, newdata;
-                    new_re_levels=:missing)
+                    new_re_levels=:missing, β=coef(m))
     StatsAPI.predict(m::GeneralizedLinearMixedModel, newdata;
-                    new_re_levels=:missing, type=:response)
+                    new_re_levels=:missing, type=:response, β=coef(m))
 
 Predict response for new data.
 
@@ -65,13 +65,21 @@ whether the predictions should be returned on the scale of linear predictor
 (`:linpred`) or on the response scale (`:response`). If you don't know the
 difference between these terms, then you probably want `type=:response`.
 
+By default, predictions use the model's own estimated fixed effects
+(`coef(m)`). A different coefficient vector can be supplied via `β`, e.g.
+to compute predictions for a hypothetical or externally specified set of
+coefficients. `β` can be specified either as a pivoted, full rank
+coefficient vector (cf. [`fixef`](@ref)) or as an unpivoted full dimension
+coefficient vector (cf. [`coef`](@ref)), where the entries corresponding to
+redundant columns will be ignored.
+
 Regression weights are not yet supported in prediction.
 Similarly, offsets are also not supported for `GeneralizedLinearMixedModel`.
 """
 function StatsAPI.predict(
-    m::LinearMixedModel, newdata::Tables.ColumnTable; new_re_levels=:missing
+    m::LinearMixedModel, newdata::Tables.ColumnTable; new_re_levels=:missing, β=coef(m)
 )
-    return _predict(m, newdata, coef(m)[pivot(m)]; new_re_levels)
+    return _predict(m, newdata, _pivotbeta(m, β); new_re_levels)
 end
 
 function StatsAPI.predict(
@@ -79,10 +87,11 @@ function StatsAPI.predict(
     newdata::Tables.ColumnTable;
     new_re_levels=:population,
     type=:response,
+    β=coef(m),
 )
     type in (:linpred, :response) || throw(ArgumentError("Invalid value for type: $(type)"))
     # want pivoted but not truncated
-    y = _predict(m.LMM, newdata, coef(m)[pivot(m)]; new_re_levels)
+    y = _predict(m.LMM, newdata, _pivotbeta(m, β); new_re_levels)
 
     return type == :linpred ? y : broadcast!(Base.Fix1(linkinv, Link(m)), y, y)
 end
@@ -130,6 +139,25 @@ function _prediction_design(m::MixedModel{T}, newdata) where {T}
     _, Xs = modelcols(form, newdata)
     reterms, feterms = _split_re_fe_terms(Xs, form, T)
     return PredictionDesign{T}(only(feterms), reterms)
+end
+
+# normalize a user-supplied β (pivoted+truncated, cf. fixef, or unpivoted+full, cf. coef)
+# to the pivoted-but-not-truncated form that _predict expects, zeroing out any
+# redundant-column entries so that they're ignored regardless of their value
+function _pivotbeta(m::MixedModel{T}, β) where {T}
+    piv = pivot(m)
+    rnk = rank(m)
+    length(β) == length(piv) || length(β) == rnk ||
+        throw(ArgumentError("You must specify all (non-singular) βs"))
+    β = convert(Vector{T}, collect(β))
+    if length(β) == length(piv)
+        β = β[piv]
+        rnk == length(piv) || fill!(view(β, (rnk + 1):length(piv)), zero(T))
+        return β
+    end
+    full = zeros(T, length(piv))
+    copyto!(full, β)
+    return full
 end
 
 # β is separated out here because m.β != m.LMM.β depending on how β is estimated for GLMM

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -153,17 +153,10 @@ end
 function simulate!(
     rng::AbstractRNG, y::AbstractVector, m::LinearMixedModel{T}; β=fixef(m), σ=m.σ, θ=m.θ
 ) where {T}
-    length(β) == length(pivot(m)) || length(β) == rank(m) ||
-        throw(ArgumentError("You must specify all (non-singular) βs"))
-
-    β = convert(Vector{T}, β)
+    β = _pivotbeta(m, β; truncate=true)
     σ = T(σ)
     θ = convert(Vector{T}, θ)
     isempty(θ) || setθ!(m, θ)
-
-    if length(β) == length(pivot(m))
-        β = view(view(β, pivot(m)), 1:rank(m))
-    end
 
     # initialize y to standard normal
     randn!(rng, y)
@@ -231,8 +224,8 @@ function _simulate!(
     θ,
     resp=nothing,
 ) where {T}
-    length(β) == length(pivot(m)) || length(β) == m.feterm.rank ||
-        throw(ArgumentError("You must specify all (non-singular) βs"))
+    # unlike LMM, GLMM stores the truncated, pivoted vector directly
+    β = _pivotbeta(m, β; truncate=true)
 
     dispersion_parameter(m) ||
         ismissing(σ) ||
@@ -242,7 +235,6 @@ function _simulate!(
             ),
         )
 
-    β = convert(Vector{T}, β)
     if σ !== missing
         σ = T(σ)
     end
@@ -250,10 +242,6 @@ function _simulate!(
 
     d = m.resp.d
 
-    if length(β) == length(pivot(m))
-        # unlike LMM, GLMM stores the truncated, pivoted vector directly
-        β = view(view(β, pivot(m)), 1:rank(m))
-    end
     fast = (length(m.θ) == length(m.optsum.final))
     setpar! = fast ? setθ! : setβθ!
     params = fast ? θ : vcat(β, θ)

--- a/test/predict.jl
+++ b/test/predict.jl
@@ -7,6 +7,7 @@ using StableRNGs
 using Tables
 using Test
 
+using GLM
 using GLM: Link, linkfun, linkinv
 using MixedModelsDatasets: dataset
 
@@ -180,6 +181,38 @@ end
             @test m_nonpiv.feterm.piv == [2, 3, 1]
             @test @suppress(predict(m_nonpiv, df_nonpiv)) ≈ fitted(m_nonpiv)
         end
+    end
+
+    @testset "custom β" begin
+        m = first(models(:sleepstudy))
+        pred_default = predict(m, slp)
+
+        @test predict(m, slp; β=coef(m)) ≈ pred_default
+        @test predict(m, slp; β=fixef(m)) ≈ pred_default
+
+        Δ = zeros(length(coef(m)))
+        Δ[2] = 1.5
+        pred_custom = predict(m, slp; β=coef(m) .+ Δ)
+        @test pred_custom ≈ pred_default .+ view(m.X, :, 2) .* 1.5
+
+        @test_throws ArgumentError predict(m, slp; β=ones(length(coef(m)) + 1))
+
+        # rank-deficient: an arbitrary value in the redundant column's entry
+        # must be ignored, regardless of the value used
+        slprd = transform(slp, :days => ByRow(x -> 2x) => :days2)
+        mrd = @suppress fit(
+            MixedModel,
+            @formula(reaction ~ 1 + days + days2 + (1 | subj)),
+            slprd;
+            progress=false,
+        )
+        predrd_default = @suppress predict(mrd, slprd)
+        redundant_idx = last(mrd.feterm.piv)
+        βrd = copy(coef(mrd))
+        @test βrd[redundant_idx] == -0.0
+        βrd[redundant_idx] = 12345.6
+        @test @suppress(predict(mrd, slprd; β=βrd)) ≈ predrd_default
+        @test predict(mrd, slprd; β=fixef(mrd)) ≈ predrd_default
     end
 
     @testset "transformed response" begin


### PR DESCRIPTION
- [x] add entry in NEWS.md
- [x] after opening this PR, add a reference and run `docs/NEWS-update.jl` to update the cross-references.
- [x] I've bumped the version appropriately
